### PR TITLE
feat : gradle-spring project를 초기 설정 PAR-181

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ java {
 
 repositories {
     mavenCentral()
-    maven { url 'https://repo.spring.io/milestone' }
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-webtestclient'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-webtestclient'
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
     // lombok

--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,13 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     sourceCompatibility = '17'
+    targetCompatibility = 17
+
 }
 
 repositories {
     mavenCentral()
-    maven { url 'https://jitpack.io' }
+    maven { url 'https://repo.spring.io/milestone' }
 }
 
 configurations {
@@ -23,23 +25,14 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+
+    asciidoctorExtensions
 }
 
 ext {
     set('snippetsDir', file("build/generated-snippets"))
 }
 
-asciidoctor {
-    configurations 'asciidoctorExt'
-    baseDirFollowsSourceFile()
-    inputs.dir snippetsDir
-
-    dependsOn test
-}
-
-asciidoctor.doFirst {
-    delete file('build/resources/main/static/docs')
-}
 
 task createDocument(type: Copy) {
     dependsOn asciidoctor
@@ -55,19 +48,24 @@ bootJar {
 dependencies {
     //rest docs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
-
-    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    developmentOnly 'io.netty:netty-resolver-dns-native-macos:4.1.94.Final:osx-aarch_64'
     //mapstruct
     implementation 'org.mapstruct:mapstruct:1.5.1.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.1.Final'
     annotationProcessor "org.projectlombok:lombok-mapstruct-binding:0.2.0"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-webtestclient'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-webtestclient'
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
 }
 
@@ -76,7 +74,7 @@ jar {
 }
 
 jacoco {
-    toolVersion = '0.8.7'
+    toolVersion = '0.8.8'
 }
 
 test {
@@ -85,7 +83,22 @@ test {
     finalizedBy 'jacocoTestReport'
 }
 
+asciidoctor {
+    configurations "asciidoctorExtensions"
+    inputs.dir snippetsDir
+    dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from ("${asciidoctor.outputDir}/html5") {
+        into 'static/docs'
+    }
+}
+
+
 jacocoTestReport {
+    dependsOn test
     reports {
         html.enabled true
     }
@@ -124,10 +137,13 @@ jacocoTestCoverageVerification {
                     '**.*Application*',
                     '**.*Request*',
                     '**.*Response*',
-                    '**.*config*',
+                    '**.*Config*',
                     '**.*Exception*',
+                    '**.*Handler*',
                     '**.*Mapper*',
                     '**.*ControllerAdvice*',
+                    '**.WebfluxAuthFilter*',
+                    '**.global.security.jwt.**'
             ]
         }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'application'
+rootProject.name = 'party-run-matching-service'

--- a/src/main/java/online/partyrun/partyrunmatchingservice/PartyRunMatchingServiceApplication.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/PartyRunMatchingServiceApplication.java
@@ -1,12 +1,12 @@
-package online.partyrun.application;
+package online.partyrun.partyrunmatchingservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class Application {
+public class PartyRunMatchingServiceApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
+        SpringApplication.run(PartyRunMatchingServiceApplication.class, args);
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/PartyRunMatchingServiceApplicationTests.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/PartyRunMatchingServiceApplicationTests.java
@@ -1,10 +1,10 @@
-package online.partyrun.application;
+package online.partyrun.partyrunmatchingservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class ApplicationTests {
+class PartyRunMatchingServiceApplicationTests {
 
     @Test
     void contextLoads() {}


### PR DESCRIPTION
## 변경 사항
- gradle root 디렉터리 변경
- jacoco 설정 변경
- client docs 추가
## 사유(Option) 
기존 템플릿 설정대로 했을 때 root package 설정이 안돼서 build 가 안될 뿐더러
 jacoco 실행조차 안되는 문제가 발생했습니다.
 webflux 환경에 맞게 초기 설정이 필요합니다.

## 테스트 방식
build가 성공적으로 수행되도록 진행했습니다
