### PR TITLE
feat : waiting 관련 SSE 구독 로직 구현

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/dto/WaitingEvent.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/dto/WaitingEvent.java
@@ -1,3 +1,0 @@
-package online.partyrun.partyrunmatchingservice.domain.waiting.dto;
-
-public class WaitingEvent {}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/dto/WaitingStatus.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/dto/WaitingStatus.java
@@ -1,7 +1,6 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.dto;
 
 public enum WaitingStatus {
-    REGISTERED,
     CONNECTED,
     MATCHED
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingService.java
@@ -24,7 +24,6 @@ public class WaitingService {
         return member.map(
                 id -> {
                     sseHandler.create(id);
-                    sseHandler.sendEvent(id, WaitingStatus.REGISTERED);
                     // TODO 대기열 요청 등록
                     return new MessageResponse(id + "님 대기열 등록");
                 });

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/sse/MultiSinkHandler.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/sse/MultiSinkHandler.java
@@ -29,7 +29,6 @@ public class MultiSinkHandler<K, V> implements ServerSentEventHandler<K, V> {
     public Flux<V> connect(final K key) {
         return getSink(key)
                 .asFlux()
-                .subscribeOn(Schedulers.boundedElastic())
                 .timeout(timeout())
                 .doOnCancel(() -> sinks.remove(key))
                 .doOnError(

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
@@ -49,8 +49,8 @@ class WaitingControllerTest extends WebfluxDocsTest {
     @DisplayName("get : WaitingEventStream 요청")
     void getWaitingEventStream() {
 
-        given(waitingService.getEventStream(any()))
-                .willReturn(Flux.just(WaitingStatus.REGISTERED, WaitingStatus.CONNECTED));
+        given(waitingService.getEventStream(any(Mono.class)))
+                .willReturn(Flux.just(WaitingStatus.CONNECTED, WaitingStatus.MATCHED));
 
         client.get()
                 .uri("/waiting/event")

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingServiceTest.java
@@ -40,16 +40,6 @@ class WaitingServiceTest {
             assertThat(sseHandler.getConnectors()).contains(user1.block());
         }
 
-        @Test
-        @DisplayName("REGISTERED 이벤트를 발행한다.")
-        void publishRegistered() {
-            waitingService.create(user1, new CreateWaitingRequest(1000)).block();
-
-            StepVerifier.create(sseHandler.connect(user1.block()))
-                    .assertNext(res -> assertThat(res).isEqualTo(WaitingStatus.REGISTERED))
-                    .thenCancel()
-                    .verify();
-        }
     }
 
     @Nested
@@ -61,9 +51,11 @@ class WaitingServiceTest {
             sseHandler.create(user1.block());
 
             StepVerifier.create(waitingService.getEventStream(user1))
-                    .assertNext(res -> assertThat(res).isEqualTo(WaitingStatus.CONNECTED))
+                    .expectNext(WaitingStatus.CONNECTED)
                     .thenCancel()
                     .verify();
         }
     }
+
+
 }


### PR DESCRIPTION
## 변경 사항
Waiting 관련 Server Sent Event 구독하는 로직을 구현했습니다.
기존 WaitingEvent에서 WaitingStatus로 클래스명을 변경한 후 Status를 추가했습니다.

## 테스트 방식
구현내용 관련 단위 테스트 추가했습니다
