### PR TITLE
feat : 클라이언트가 matching에 대한 수락/거절 요청 전송 구현 #PAR-193

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -13,3 +13,9 @@ operation::create-waiting[snippets='http-request,http-response']
 === waiting event stream 요청
 
 operation::get-waiting-event[snippets='http-request,http-response']
+
+== Matching
+
+=== Matching 수락/거절 전송
+
+operation::create-matching[snippets='http-request,http-response']

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingController.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingController.java
@@ -3,11 +3,14 @@ package online.partyrun.partyrunmatchingservice.domain.matching.controller;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
 import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
 import reactor.core.publisher.Mono;
 
 import java.security.Principal;

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingController.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingController.java
@@ -1,0 +1,30 @@
+package online.partyrun.partyrunmatchingservice.domain.matching.controller;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
+import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@RequestMapping("matching")
+public class MatchingController {
+    MatchingService matchingService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<MessageResponse> postMatchStatus(
+            Mono<Authentication> auth, @RequestBody MatchingRequest request) {
+        return matchingService
+                .setMemberStatus(auth.map(Principal::getName), request)
+                .flatMap(i -> Mono.just(new MessageResponse("참여여부 등록")));
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingRequest.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingRequest.java
@@ -1,0 +1,4 @@
+package online.partyrun.partyrunmatchingservice.domain.matching.controller;
+
+public record MatchingRequest(boolean isJoin){
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingRequest.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingRequest.java
@@ -1,4 +1,3 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.controller;
 
-public record MatchingRequest(boolean isJoin){
-}
+public record MatchingRequest(boolean isJoin) {}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
@@ -50,6 +50,7 @@ public class Matching {
     public void updateStatus() {
         this.status = generateMatchingStatus();
     }
+
     public boolean isWait() {
         return this.status.isWait();
     }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
@@ -18,8 +18,7 @@ import java.util.Objects;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Matching {
     private static final int MIN_DISTANCE = 1;
-    @Id
-    String id;
+    @Id String id;
     List<MatchingMember> members;
     int distance;
     MatchingStatus status = MatchingStatus.WAIT;

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
@@ -47,20 +47,12 @@ public class Matching {
         members.forEach(member -> member.changeStatus(MatchingMemberStatus.CANCELED));
     }
 
-    public void updateMemberStatus(final String memberId, final MatchingMemberStatus status) {
-        final MatchingMember member = findMember(memberId);
-        member.changeStatus(status);
-        this.status = getMatchStatus();
+    public boolean updateStatus() {
+        this.status = generateMatchingStatus();
+        return !this.status.equals(MatchingStatus.WAIT);
     }
 
-    private MatchingMember findMember(String memberId) {
-        return this.members.stream()
-                .filter(member -> member.equalsId(memberId))
-                .findAny()
-                .orElseThrow();
-    }
-
-    private MatchingStatus getMatchStatus() {
+    private MatchingStatus generateMatchingStatus() {
         final List<MatchingMemberStatus> memberStatuses =
                 members.stream().map(MatchingMember::getStatus).toList();
         if (memberStatuses.contains(MatchingMemberStatus.CANCELED)) {
@@ -69,6 +61,6 @@ public class Matching {
         if (memberStatuses.stream().allMatch(MatchingMemberStatus.READY::equals)) {
             return MatchingStatus.SUCCESS;
         }
-        return this.status;
+        return MatchingStatus.WAIT;
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
@@ -47,9 +47,11 @@ public class Matching {
         members.forEach(member -> member.changeStatus(MatchingMemberStatus.CANCELED));
     }
 
-    public boolean updateStatus() {
+    public void updateStatus() {
         this.status = generateMatchingStatus();
-        return !this.status.equals(MatchingStatus.WAIT);
+    }
+    public boolean isWait() {
+        return this.status.isWait();
     }
 
     private MatchingStatus generateMatchingStatus() {

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
@@ -18,7 +18,8 @@ import java.util.Objects;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Matching {
     private static final int MIN_DISTANCE = 1;
-    @Id String id;
+    @Id
+    String id;
     List<MatchingMember> members;
     int distance;
     MatchingStatus status = MatchingStatus.WAIT;
@@ -56,12 +57,10 @@ public class Matching {
     }
 
     private MatchingStatus generateMatchingStatus() {
-        final List<MatchingMemberStatus> memberStatuses =
-                members.stream().map(MatchingMember::getStatus).toList();
-        if (memberStatuses.contains(MatchingMemberStatus.CANCELED)) {
+        if (this.members.stream().anyMatch(MatchingMember::isCanceled)) {
             return MatchingStatus.CANCEL;
         }
-        if (memberStatuses.stream().allMatch(MatchingMemberStatus.READY::equals)) {
+        if (this.members.stream().allMatch(MatchingMember::isReady)) {
             return MatchingStatus.SUCCESS;
         }
         return MatchingStatus.WAIT;

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMember.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMember.java
@@ -32,4 +32,12 @@ public class MatchingMember {
     public void changeStatus(final MatchingMemberStatus status) {
         this.status = status;
     }
+
+    public boolean isCanceled() {
+        return status == MatchingMemberStatus.CANCELED;
+    }
+
+    public boolean isReady() {
+        return status == MatchingMemberStatus.READY;
+    }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMember.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMember.java
@@ -32,8 +32,4 @@ public class MatchingMember {
     public void changeStatus(final MatchingMemberStatus status) {
         this.status = status;
     }
-
-    public boolean equalsId(final String id) {
-        return this.id.equals(id);
-    }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMemberStatus.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMemberStatus.java
@@ -3,5 +3,12 @@ package online.partyrun.partyrunmatchingservice.domain.matching.entity;
 public enum MatchingMemberStatus {
     NO_RESPONSE,
     READY,
-    CANCELED
+    CANCELED;
+
+    public static MatchingMemberStatus getByIsJoin(boolean isJoin) {
+        if(isJoin) {
+            return READY;
+        }
+        return CANCELED;
+    }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMemberStatus.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMemberStatus.java
@@ -6,7 +6,7 @@ public enum MatchingMemberStatus {
     CANCELED;
 
     public static MatchingMemberStatus getByIsJoin(boolean isJoin) {
-        if(isJoin) {
+        if (isJoin) {
             return READY;
         }
         return CANCELED;

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingStatus.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingStatus.java
@@ -3,5 +3,9 @@ package online.partyrun.partyrunmatchingservice.domain.matching.entity;
 public enum MatchingStatus {
     WAIT,
     SUCCESS,
-    CANCEL
+    CANCEL;
+
+    public boolean isWait() {
+        return this == WAIT;
+    }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -2,7 +2,9 @@ package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
+
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -13,5 +15,4 @@ public interface MatchingRepository extends ReactiveMongoRepository<Matching, St
             List<String> memberIds, MatchingMemberStatus memberStatus);
 
     Mono<Matching> findByMembersIdAndMembersStatus(String id, MatchingMemberStatus status);
-    
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -2,9 +2,9 @@ package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
-
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
-
+import org.springframework.data.mongodb.repository.Update;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -15,4 +15,8 @@ public interface MatchingRepository extends ReactiveMongoRepository<Matching, St
             List<String> memberIds, MatchingMemberStatus memberStatus);
 
     Mono<Matching> findByMembersIdAndMembersStatus(String id, MatchingMemberStatus status);
+
+    @Query("{'id': ?0, 'members.id': ?1}")
+    @Update("{$set : {'members.$.status': ?2}}")
+    Mono<Void> updateMatchingMemberStatus(String matchingId, String memberId, MatchingMemberStatus status);
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -2,14 +2,16 @@ package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
-
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
-
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
 public interface MatchingRepository extends ReactiveMongoRepository<Matching, String> {
     Flux<Matching> findAllByMembersIdInAndMembersStatus(
             List<String> memberIds, MatchingMemberStatus memberStatus);
+
+    Mono<Matching> findByMembersIdAndMembersStatus(String id, MatchingMemberStatus status);
+    
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -2,9 +2,11 @@ package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
+
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.data.mongodb.repository.Update;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -18,5 +20,6 @@ public interface MatchingRepository extends ReactiveMongoRepository<Matching, St
 
     @Query("{'id': ?0, 'members.id': ?1}")
     @Update("{$set : {'members.$.status': ?2}}")
-    Mono<Void> updateMatchingMemberStatus(String matchingId, String memberId, MatchingMemberStatus status);
+    Mono<Void> updateMatchingMemberStatus(
+            String matchingId, String memberId, MatchingMemberStatus status);
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -3,13 +3,16 @@ package online.partyrun.partyrunmatchingservice.domain.matching.service;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunmatchingservice.domain.matching.controller.MatchingRequest;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.repository.MatchingRepository;
+
 import org.springframework.stereotype.Service;
+
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -52,14 +55,19 @@ public class MatchingService {
                                         }));
     }
 
-    public Mono<Matching> setMemberStatus(final Mono<String> member, final MatchingRequest request) {
+    public Mono<Matching> setMemberStatus(
+            final Mono<String> member, final MatchingRequest request) {
         return member.flatMap(
                 mid ->
                         matchingRepository
-                                .findByMembersIdAndMembersStatus(mid, MatchingMemberStatus.NO_RESPONSE)
+                                .findByMembersIdAndMembersStatus(
+                                        mid, MatchingMemberStatus.NO_RESPONSE)
                                 .flatMap(
                                         match -> {
-                                            match.updateMemberStatus(mid,MatchingMemberStatus.getByIsJoin(request.isJoin()));
+                                            match.updateMemberStatus(
+                                                    mid,
+                                                    MatchingMemberStatus.getByIsJoin(
+                                                            request.isJoin()));
                                             return matchingRepository.save(match);
                                         })
                                 .doOnSuccess(this::sendEvent));
@@ -69,6 +77,7 @@ public class MatchingService {
         matching.getMembers()
                 .forEach(
                         member ->
-                                matchingSinkHandler.sendEvent(member.getId(), new MatchEvent(matching)));
+                                matchingSinkHandler.sendEvent(
+                                        member.getId(), new MatchEvent(matching)));
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -62,18 +62,31 @@ public class MatchingService {
                                 matchingRepository
                                         .findByMembersIdAndMembersStatus(
                                                 mid, MatchingMemberStatus.NO_RESPONSE)
-                                        .flatMap(match ->
-                                                matchingRepository.updateMatchingMemberStatus(match.getId(), mid,
-                                                                MatchingMemberStatus.getByIsJoin(request.isJoin()))
-                                                        .then(Mono.defer(() -> matchingRepository.findById(match.getId())))
-                                        )
-                ).flatMap(match -> {
-                    final boolean isUpdated = match.updateStatus();
-                    if(isUpdated) {
-                        return matchingRepository.save(match);
-                    }
-                   return Mono.just(match);
-                })
+                                        .flatMap(
+                                                match ->
+                                                        matchingRepository
+                                                                .updateMatchingMemberStatus(
+                                                                        match.getId(),
+                                                                        mid,
+                                                                        MatchingMemberStatus
+                                                                                .getByIsJoin(
+                                                                                        request
+                                                                                                .isJoin()))
+                                                                .then(
+                                                                        Mono.defer(
+                                                                                () ->
+                                                                                        matchingRepository
+                                                                                                .findById(
+                                                                                                        match
+                                                                                                                .getId())))))
+                .flatMap(
+                        match -> {
+                            final boolean isUpdated = match.updateStatus();
+                            if (isUpdated) {
+                                return matchingRepository.save(match);
+                            }
+                            return Mono.just(match);
+                        })
                 .doOnSuccess(this::sendEvent);
     }
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -3,15 +3,13 @@ package online.partyrun.partyrunmatchingservice.domain.matching.service;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
+import online.partyrun.partyrunmatchingservice.domain.matching.controller.MatchingRequest;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.repository.MatchingRepository;
-
 import org.springframework.stereotype.Service;
-
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -52,5 +50,25 @@ public class MatchingService {
                                             matchingSinkHandler.sendEvent(
                                                     member.getId(), new MatchEvent(match));
                                         }));
+    }
+
+    public Mono<Matching> setMemberStatus(final Mono<String> member, final MatchingRequest request) {
+        return member.flatMap(
+                mid ->
+                        matchingRepository
+                                .findByMembersIdAndMembersStatus(mid, MatchingMemberStatus.NO_RESPONSE)
+                                .flatMap(
+                                        match -> {
+                                            match.updateMemberStatus(mid,MatchingMemberStatus.getByIsJoin(request.isJoin()));
+                                            return matchingRepository.save(match);
+                                        })
+                                .doOnSuccess(this::sendEvent));
+    }
+
+    private void sendEvent(final Matching matching) {
+        matching.getMembers()
+                .forEach(
+                        member ->
+                                matchingSinkHandler.sendEvent(member.getId(), new MatchEvent(matching)));
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -81,8 +81,8 @@ public class MatchingService {
                                                                                                                 .getId())))))
                 .flatMap(
                         match -> {
-                            final boolean isUpdated = match.updateStatus();
-                            if (isUpdated) {
+                            match.updateStatus();
+                            if (!match.isWait()) {
                                 return matchingRepository.save(match);
                             }
                             return Mono.just(match);

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
@@ -1,0 +1,44 @@
+package online.partyrun.partyrunmatchingservice.domain.matching.controller;
+
+import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
+import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
+import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
+import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+
+@ContextConfiguration(classes = MatchingController.class)
+@DisplayName("MatchingController")
+@WithMockUser
+class MatchingControllerTest extends WebfluxDocsTest {
+    @MockBean
+    MatchingService matchingService;
+    final Matching matching = new Matching(List.of(new MatchingMember("현준"), new MatchingMember("준혁")), 1000);
+
+    @Test
+    @DisplayName("post : match 수락 여부 전송")
+    void postMatching() {
+        given(matchingService.setMemberStatus(any(), any())).willReturn(Mono.just(matching));
+
+        client.post()
+                .uri("/matching")
+                .bodyValue(new MatchingRequest(true))
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isCreated()
+                .expectBody()
+                .consumeWith(document("create-matching"));
+    }
+}

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
@@ -1,30 +1,32 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @ContextConfiguration(classes = MatchingController.class)
 @DisplayName("MatchingController")
 @WithMockUser
 class MatchingControllerTest extends WebfluxDocsTest {
-    @MockBean
-    MatchingService matchingService;
-    final Matching matching = new Matching(List.of(new MatchingMember("현준"), new MatchingMember("준혁")), 1000);
+    @MockBean MatchingService matchingService;
+    final Matching matching =
+            new Matching(List.of(new MatchingMember("현준"), new MatchingMember("준혁")), 1000);
 
     @Test
     @DisplayName("post : match 수락 여부 전송")

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
@@ -1,21 +1,15 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.entity;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidDistanceException;
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidMembersException;
-
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Matching")
 class MatchingTest {
@@ -34,30 +28,5 @@ class MatchingTest {
     void throwInvalidMember(int distance) {
         assertThatThrownBy(() -> new Matching(List.of(new MatchingMember("현준")), distance))
                 .isInstanceOf(InvalidDistanceException.class);
-    }
-
-    @Nested
-    @DisplayNameGeneration(ReplaceUnderscores.class)
-    class 참여자가_주어졌을_떄 {
-
-        List<String> members = List.of("현준", "성우", "준혁");
-        final Matching matching =
-                new Matching(members.stream().map(MatchingMember::new).toList(), 1000);
-
-        @Test
-        @DisplayName("모든 맴버들이 ready 상태 시에 success 상태로 변경한다")
-        void runChangeMatchingSuccess() {
-            members.forEach(
-                    member -> matching.updateMemberStatus(member, MatchingMemberStatus.READY));
-
-            assertThat(matching.getStatus()).isEqualTo(MatchingStatus.SUCCESS);
-        }
-
-        @Test
-        @DisplayName("한 명이라도 cancel 시에 cancel 상태로 변경한다")
-        void runChangeMatchingCancel() {
-            matching.updateMemberStatus(members.get(1), MatchingMemberStatus.CANCELED);
-            assertThat(matching.getStatus()).isEqualTo(MatchingStatus.CANCEL);
-        }
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
@@ -1,15 +1,16 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.entity;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidDistanceException;
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidMembersException;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Matching")
 class MatchingTest {

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
@@ -1,20 +1,22 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+
 import reactor.test.StepVerifier;
 
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DataMongoTest
 @DisplayName("MatchingRepository")
@@ -59,9 +61,13 @@ class MatchingRepositoryTest {
     void updateMatchingMemberStatus() {
         final Matching matching = matchRepository.save(new Matching(members, 1000)).block();
 
-        matchRepository.updateMatchingMemberStatus(matching.getId(), members.get(0).getId(), MatchingMemberStatus.READY).block();
+        matchRepository
+                .updateMatchingMemberStatus(
+                        matching.getId(), members.get(0).getId(), MatchingMemberStatus.READY)
+                .block();
 
-        final List<MatchingMember> getMembers = matchRepository.findById(matching.getId()).block().getMembers();
+        final List<MatchingMember> getMembers =
+                matchRepository.findById(matching.getId()).block().getMembers();
 
         assertThat(getMembers.get(0).getStatus()).isEqualTo(MatchingMemberStatus.READY);
         assertThat(getMembers.get(1).getStatus()).isEqualTo(MatchingMemberStatus.NO_RESPONSE);

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
@@ -83,7 +83,7 @@ class MatchingServiceTest {
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-    class Member생성을_진행한_후_Member_상태_변경_오청시 {
+    class Member생성을_진행한_후_Member_상태_변경_요청시 {
         Mono<String> 현준 = Mono.just(members.get(0));
         Mono<String> 성우 = Mono.just(members.get(1));
         Mono<String> 준혁 = Mono.just(members.get(2));

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
@@ -1,26 +1,29 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import online.partyrun.partyrunmatchingservice.config.redis.RedisTestConfig;
+import online.partyrun.partyrunmatchingservice.domain.matching.controller.MatchingRequest;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.repository.MatchingRepository;
+import online.partyrun.partyrunmatchingservice.domain.waiting.root.RunningDistance;
 import online.partyrun.partyrunmatchingservice.global.sse.ServerSentEventHandler;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
+import org.springframework.context.annotation.Import;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @SpringBootTest
 @DisplayName("MatchingService")
+@Import(RedisTestConfig.class)
 class MatchingServiceTest {
     @Autowired MatchingService matchingService;
 
@@ -29,6 +32,12 @@ class MatchingServiceTest {
 
     final List<String> members = List.of("현준", "성우", "준혁");
     final int distance = 1000;
+
+    @AfterEach
+    void cleanup() {
+        sseHandler.shutdown();
+        matchingRepository.deleteAll().block();
+    }
 
     @Test
     @DisplayName("matching을 생성한다")
@@ -64,4 +73,114 @@ class MatchingServiceTest {
         assertThat(sseHandler.getConnectors().stream().filter(m -> m.equals(members.get(0))))
                 .hasSize(1);
     }
+
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class Member생성을_진행한_후_Member_상태_변경_오청시 {
+        Mono<String> 현준 = Mono.just(members.get(0));
+        Mono<String> 성우 = Mono.just(members.get(1));
+        Mono<String> 준혁 = Mono.just(members.get(2));
+        MatchingRequest 수락 = new MatchingRequest(true);
+        MatchingRequest 거절 = new MatchingRequest(false);
+
+        @Test
+        @DisplayName("member 상태를 설정한다")
+        void runSetMemberStatus() {
+            matchingService.create(members, distance).block();
+
+            StepVerifier.create(matchingService.setMemberStatus(현준, 수락))
+                    .assertNext(
+                            match -> {
+                                assertThat(match.getMembers().stream().map(MatchingMember::getId))
+                                        .contains("현준", "성우", "준혁");
+                                assertThat(match.getDistance())
+                                        .isEqualTo(distance);
+                                assertThat(match.getStatus()).isEqualTo(MatchingStatus.WAIT);
+                            })
+                    .verifyComplete();
+        }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class member가_거절할_경우 {
+            @Test
+            @DisplayName("매치 상태를 캔슬로 변경한다")
+            void runSetMemberStatus() {
+                matchingService.create(members, distance).block();
+
+                StepVerifier.create(matchingService.setMemberStatus(현준, 거절))
+                        .assertNext(
+                                match -> {
+                                    assertThat(match.getMembers().stream().map(MatchingMember::getId))
+                                            .contains("현준", "성우", "준혁");
+                                    assertThat(match.getDistance())
+                                            .isEqualTo(RunningDistance.M1000.getMeter());
+                                    assertThat(match.getStatus()).isEqualTo(MatchingStatus.CANCEL);
+                                })
+                        .verifyComplete();
+            }
+
+            @Test
+            @DisplayName("이전에 사람들이 수락을 했어도 캔슬로 변경한다")
+            void runCancel() {
+                matchingService.create(members, distance).block();
+                matchingService.setMemberStatus(성우, 수락).block();
+                matchingService.setMemberStatus(준혁, 수락).block();
+
+                StepVerifier.create(matchingService.setMemberStatus(현준, 거절))
+                        .assertNext(
+                                match -> {
+                                    assertThat(match.getMembers().stream().map(MatchingMember::getId))
+                                            .contains("현준", "성우", "준혁");
+                                    assertThat(match.getDistance())
+                                            .isEqualTo(RunningDistance.M1000.getMeter());
+                                    assertThat(match.getStatus()).isEqualTo(MatchingStatus.CANCEL);
+                                })
+                        .verifyComplete();
+            }
+
+            @Test
+            @DisplayName("내가 수락을 했어도 다른사람이 거절하면 캔슬로 변경한다")
+            void runCancelIf() {
+                matchingService.create(members, distance).block();
+                matchingService.setMemberStatus(성우, 수락).block();
+                matchingService.setMemberStatus(준혁, 거절).block();
+
+                StepVerifier.create(matchingService.setMemberStatus(현준, 수락))
+                        .assertNext(
+                                match -> {
+                                    assertThat(match.getMembers().stream().map(MatchingMember::getId))
+                                            .contains("현준", "성우", "준혁");
+                                    assertThat(match.getDistance())
+                                            .isEqualTo(RunningDistance.M1000.getMeter());
+                                    assertThat(match.getStatus()).isEqualTo(MatchingStatus.CANCEL);
+                                })
+                        .verifyComplete();
+            }
+        }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class member모두가_수락한_경우 {
+            @Test
+            @DisplayName("member 상태를 설정한 후에 매치 상태도 성공으로 변경한다")
+            void runSetMemberStatus() {
+                matchingService.create(members, distance).block();
+                matchingService.setMemberStatus(성우, 수락).block();
+                matchingService.setMemberStatus(준혁, 수락).block();
+                StepVerifier.create(matchingService.setMemberStatus(현준, 수락))
+                        .assertNext(
+                                match -> {
+                                    assertThat(match.getMembers().stream().map(MatchingMember::getId))
+                                            .contains("현준", "성우", "준혁");
+                                    assertThat(match.getDistance())
+                                            .isEqualTo(RunningDistance.M1000.getMeter());
+                                    assertThat(match.getStatus()).isEqualTo(MatchingStatus.SUCCESS);
+                                })
+                        .verifyComplete();
+            }
+        }
+    }
+
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
@@ -1,5 +1,7 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import online.partyrun.partyrunmatchingservice.config.redis.RedisTestConfig;
 import online.partyrun.partyrunmatchingservice.domain.matching.controller.MatchingRequest;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
@@ -10,16 +12,16 @@ import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingSt
 import online.partyrun.partyrunmatchingservice.domain.matching.repository.MatchingRepository;
 import online.partyrun.partyrunmatchingservice.domain.waiting.root.RunningDistance;
 import online.partyrun.partyrunmatchingservice.global.sse.ServerSentEventHandler;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @DisplayName("MatchingService")
@@ -74,7 +76,6 @@ class MatchingServiceTest {
                 .hasSize(1);
     }
 
-
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class Member생성을_진행한_후_Member_상태_변경_오청시 {
@@ -94,8 +95,7 @@ class MatchingServiceTest {
                             match -> {
                                 assertThat(match.getMembers().stream().map(MatchingMember::getId))
                                         .contains("현준", "성우", "준혁");
-                                assertThat(match.getDistance())
-                                        .isEqualTo(distance);
+                                assertThat(match.getDistance()).isEqualTo(distance);
                                 assertThat(match.getStatus()).isEqualTo(MatchingStatus.WAIT);
                             })
                     .verifyComplete();
@@ -112,7 +112,9 @@ class MatchingServiceTest {
                 StepVerifier.create(matchingService.setMemberStatus(현준, 거절))
                         .assertNext(
                                 match -> {
-                                    assertThat(match.getMembers().stream().map(MatchingMember::getId))
+                                    assertThat(
+                                                    match.getMembers().stream()
+                                                            .map(MatchingMember::getId))
                                             .contains("현준", "성우", "준혁");
                                     assertThat(match.getDistance())
                                             .isEqualTo(RunningDistance.M1000.getMeter());
@@ -131,7 +133,9 @@ class MatchingServiceTest {
                 StepVerifier.create(matchingService.setMemberStatus(현준, 거절))
                         .assertNext(
                                 match -> {
-                                    assertThat(match.getMembers().stream().map(MatchingMember::getId))
+                                    assertThat(
+                                                    match.getMembers().stream()
+                                                            .map(MatchingMember::getId))
                                             .contains("현준", "성우", "준혁");
                                     assertThat(match.getDistance())
                                             .isEqualTo(RunningDistance.M1000.getMeter());
@@ -150,7 +154,9 @@ class MatchingServiceTest {
                 StepVerifier.create(matchingService.setMemberStatus(현준, 수락))
                         .assertNext(
                                 match -> {
-                                    assertThat(match.getMembers().stream().map(MatchingMember::getId))
+                                    assertThat(
+                                                    match.getMembers().stream()
+                                                            .map(MatchingMember::getId))
                                             .contains("현준", "성우", "준혁");
                                     assertThat(match.getDistance())
                                             .isEqualTo(RunningDistance.M1000.getMeter());
@@ -172,7 +178,9 @@ class MatchingServiceTest {
                 StepVerifier.create(matchingService.setMemberStatus(현준, 수락))
                         .assertNext(
                                 match -> {
-                                    assertThat(match.getMembers().stream().map(MatchingMember::getId))
+                                    assertThat(
+                                                    match.getMembers().stream()
+                                                            .map(MatchingMember::getId))
                                             .contains("현준", "성우", "준혁");
                                     assertThat(match.getDistance())
                                             .isEqualTo(RunningDistance.M1000.getMeter());
@@ -182,5 +190,4 @@ class MatchingServiceTest {
             }
         }
     }
-
 }


### PR DESCRIPTION
## 변경 사항
Matching에 대한 수락/거절을 요청하는 controller 구현
Matchiing에 수락 거절요청을 받고 맴버 상태를 변경 후 각 맴버 상태를 이벤트로 전송하게끔 구현


## 알아야할 사항
현재는 기존에 규정했던 API 문서에 맞게 작성을 했으나, matching 수락/거절이 POST matching이 맞을 지 좀 더 논의가 필요할 듯 합니다. 해당 행위가 matching을 생성하는 것이 아닌 매칭에 대한 수락/거절 정보를 전송하는 것인데. 해당 요청이 restful한 지 논의가 필요할 듯 합니다.
