### PR TITLE
Github actions + docker를 활용하여 ci/cd 파이프라인을 생성한다.

### DIFF
--- a/.github/workflows/build-docker-image-dev.yml
+++ b/.github/workflows/build-docker-image-dev.yml
@@ -1,0 +1,37 @@
+name: Build Backend Image Dev
+
+on:
+  workflow_call:
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_PASSWORD:
+        required: true
+      DOCKER_MATCHING_IMAGE_NAME:
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with jib
+        run: ./gradlew jib --image="${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_MATCHING_IMAGE_NAME }}"

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,0 +1,32 @@
+name : cd -dev
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build-back-docker-img:
+    uses: ./.github/workflows/build-docker-image-dev.yml
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      DOCKER_MATCHING_IMAGE_NAME: ${{ secrets.DOCKER_MATCHING_IMAGE_NAME }}
+
+  deploy:
+    needs: build-back-docker-img
+    runs-on: ubuntu-latest
+    steps:
+    - name: executing remote ssh commands using password
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.DEV_HOST }}
+        username: ${{ secrets.DEV_HOST_USER_NAME }}
+        key: ${{ secrets.DEV_PRIVATE_KEY }}
+        script: |
+          cd ${{ secrets.DEV_DEPLOY_DIRECTORY }}
+          docker compose stop ${{ secrets.DOCKER_MATCHING_CONTAINER_NAME }}
+          docker compose rm -f ${{ secrets.DOCKER_MATCHING_CONTAINER_NAME }}
+          docker image rm ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_MATCHING_IMAGE_NAME }}
+          docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_MATCHING_IMAGE_NAME }}
+          docker compose up -d

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ jib {
         image = "openjdk:17"
     }
     to {
-        image = "phjppo0918/party-run-matching"
         tags = ["latest"]
     }
     container {


### PR DESCRIPTION
변경된 부분
github actions의 workflow를 생성하고, 수정하였습니다.

build.gradle에 jib 설정
jib 설정에서 image 이름을 지정하지 않습니다. 이렇게 하면 로컬에서 실수로 jib 블럭을 실행했어도 도커 허브로 push 되지 않습니다.
대신 build-docker-image-dev.yml에서 image 이름을 지정합니다.

build-docker-image-deb.yml
이 파일은 docker image를 만들어 줍니다. cd-dev.yml에서 deploy 전에 이 workflow를 실행합니다.

cd-dev.yml
빌드된 파일을 실행하기 위해 서버로 ssh로 명령어를 전달합니다.

기존 컨테이너 stop
기존 컨테이너 삭제
기존 이미지 삭제
새로운 이미지 pull
docker compose 실행