### PR TITLE
feat : matching event 구독 및 이벤트 스트림 응답 로직 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -19,3 +19,7 @@ operation::get-waiting-event[snippets='http-request,http-response']
 === Matching 수락/거절 전송
 
 operation::create-matching[snippets='http-request,http-response']
+
+=== matching event stream 요청
+
+operation::get-matching-event[snippets='http-request,http-response']

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingController.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingController.java
@@ -4,13 +4,16 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
+import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
 import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.security.Principal;
@@ -29,5 +32,10 @@ public class MatchingController {
         return matchingService
                 .setMemberStatus(auth.map(Principal::getName), request)
                 .flatMap(i -> Mono.just(new MessageResponse("참여여부 등록")));
+    }
+
+    @GetMapping(path = "event", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<MatchEvent> getEventSteam(Mono<Authentication> auth) {
+        return matchingService.getEventSteam(auth.map(Principal::getName));
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -9,7 +9,6 @@ import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
-import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.repository.MatchingRepository;
 
 import org.springframework.stereotype.Service;
@@ -101,11 +100,15 @@ public class MatchingService {
     }
 
     public Flux<MatchEvent> getEventSteam(final Mono<String> member) {
-        return member.flatMapMany(id -> matchingSinkHandler.connect(id)
-                .doOnNext(event -> {
-                    if (!event.status().isWait()) {
-                        matchingSinkHandler.complete(id);
-                    }
-                }));
+        return member.flatMapMany(
+                id ->
+                        matchingSinkHandler
+                                .connect(id)
+                                .doOnNext(
+                                        event -> {
+                                            if (!event.status().isWait()) {
+                                                matchingSinkHandler.complete(id);
+                                            }
+                                        }));
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
@@ -33,7 +33,7 @@ class MatchingControllerTest extends WebfluxDocsTest {
     @Test
     @DisplayName("post : match 수락 여부 전송")
     void postMatching() {
-        given(matchingService.setMemberStatus(any(Mono.class), any()))
+        given(matchingService.setMemberStatus(any(Mono.class), any(MatchingRequest.class)))
                 .willReturn(Mono.just(matching));
 
         client.post()

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
+import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
@@ -16,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -31,7 +33,7 @@ class MatchingControllerTest extends WebfluxDocsTest {
     @Test
     @DisplayName("post : match 수락 여부 전송")
     void postMatching() {
-        given(matchingService.setMemberStatus(any(), any())).willReturn(Mono.just(matching));
+        given(matchingService.setMemberStatus(any(Mono.class), any())).willReturn(Mono.just(matching));
 
         client.post()
                 .uri("/matching")
@@ -42,5 +44,20 @@ class MatchingControllerTest extends WebfluxDocsTest {
                 .isCreated()
                 .expectBody()
                 .consumeWith(document("create-matching"));
+    }
+
+    @Test
+    @DisplayName("get : waiting event 요청")
+    void getMatching() {
+        given(matchingService.getEventSteam(any(Mono.class)))
+                .willReturn(Flux.just(new MatchEvent(matching), new MatchEvent(matching)));
+        client.get()
+                .uri("/matching/event")
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .consumeWith(document("get-matching-event"));
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
@@ -33,7 +33,8 @@ class MatchingControllerTest extends WebfluxDocsTest {
     @Test
     @DisplayName("post : match 수락 여부 전송")
     void postMatching() {
-        given(matchingService.setMemberStatus(any(Mono.class), any())).willReturn(Mono.just(matching));
+        given(matchingService.setMemberStatus(any(Mono.class), any()))
+                .willReturn(Mono.just(matching));
 
         client.post()
                 .uri("/matching")

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
@@ -126,7 +126,6 @@ class MatchingServiceTest {
                                     assertThat(match.getStatus()).isEqualTo(MatchingStatus.CANCEL);
                                 })
                         .verifyComplete();
-
             }
 
             @Test
@@ -228,14 +227,16 @@ class MatchingServiceTest {
             @DisplayName("구독을 진행시에 수락 이벤트를 받고 종료한다.")
             void runSubscribe() {
                 matchingService.create(members, 1000).block();
-                int eventCount = 1 + members.size(); //Connection 값, 각 member 수락 이벤트 값 포함
-                members.forEach(member -> matchingService.setMemberStatus(Mono.just(member), 수락).block());
+                int eventCount = 1 + members.size(); // Connection 값, 각 member 수락 이벤트 값 포함
+                members.forEach(
+                        member -> matchingService.setMemberStatus(Mono.just(member), 수락).block());
 
-                members.forEach(member ->
-                        StepVerifier.create(matchingService.getEventSteam(Mono.just(member)))
-                                .expectNextCount(eventCount)
-                                .verifyComplete()
-                );
+                members.forEach(
+                        member ->
+                                StepVerifier.create(
+                                                matchingService.getEventSteam(Mono.just(member)))
+                                        .expectNextCount(eventCount)
+                                        .verifyComplete());
                 assertThat(sseHandler.getConnectors()).isEmpty();
             }
         }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
@@ -37,6 +37,11 @@ class MatchingServiceTest {
     @Autowired MatchingRepository matchingRepository;
 
     final List<String> members = List.of("현준", "성우", "준혁");
+    Mono<String> 현준 = Mono.just(members.get(0));
+    Mono<String> 성우 = Mono.just(members.get(1));
+    Mono<String> 준혁 = Mono.just(members.get(2));
+    MatchingRequest 수락 = new MatchingRequest(true);
+    MatchingRequest 거절 = new MatchingRequest(false);
     final int distance = 1000;
 
     @BeforeEach
@@ -84,11 +89,6 @@ class MatchingServiceTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class Member생성을_진행한_후_Member_상태_변경_요청시 {
-        Mono<String> 현준 = Mono.just(members.get(0));
-        Mono<String> 성우 = Mono.just(members.get(1));
-        Mono<String> 준혁 = Mono.just(members.get(2));
-        MatchingRequest 수락 = new MatchingRequest(true);
-        MatchingRequest 거절 = new MatchingRequest(false);
 
         @Test
         @DisplayName("member 상태를 설정한다")
@@ -126,6 +126,7 @@ class MatchingServiceTest {
                                     assertThat(match.getStatus()).isEqualTo(MatchingStatus.CANCEL);
                                 })
                         .verifyComplete();
+
             }
 
             @Test
@@ -186,6 +187,18 @@ class MatchingServiceTest {
                 final Matching block = matchingRepository.findById(matcing.getId()).block();
                 assertThat(block.getStatus()).isEqualTo(MatchingStatus.SUCCESS);
             }
+
+            @Test
+            @DisplayName("구독을 진행시에 거절 이벤트를 받고 종료한다.")
+            void runSubscribe() {
+                matchingService.create(members, 1000).block();
+                matchingService.setMemberStatus(현준, 거절).block();
+
+                StepVerifier.create(matchingService.getEventSteam(현준))
+                        .expectNextCount(2)
+                        .verifyComplete();
+                assertThat(sseHandler.getConnectors()).isNotIn(현준.block());
+            }
         }
 
         @Nested
@@ -209,6 +222,21 @@ class MatchingServiceTest {
                                     assertThat(match.getStatus()).isEqualTo(MatchingStatus.SUCCESS);
                                 })
                         .verifyComplete();
+            }
+
+            @Test
+            @DisplayName("구독을 진행시에 수락 이벤트를 받고 종료한다.")
+            void runSubscribe() {
+                matchingService.create(members, 1000).block();
+                int eventCount = 1 + members.size(); //Connection 값, 각 member 수락 이벤트 값 포함
+                members.forEach(member -> matchingService.setMemberStatus(Mono.just(member), 수락).block());
+
+                members.forEach(member ->
+                        StepVerifier.create(matchingService.getEventSteam(Mono.just(member)))
+                                .expectNextCount(eventCount)
+                                .verifyComplete()
+                );
+                assertThat(sseHandler.getConnectors()).isEmpty();
             }
         }
     }


### PR DESCRIPTION
## 변경 사항
matching에 관한 이벤트를 구독하고, event stream 응답 로직을 구현했습니다.
event가 wait이 아닌 status가 되면 complete되도록 구현하였습니다.

## 알아야할 사항
기존 waitingController-waitingEventService와 구조가 유사합니다.