### PR TITLE
refactor : matchingService 로직 메서드 추출 리펙터링

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -2,7 +2,6 @@ package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
-import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
 
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -23,8 +23,4 @@ public interface MatchingRepository extends ReactiveMongoRepository<Matching, St
     @Update("{$set : {'members.$.status': ?2}}")
     Mono<Void> updateMatchingMemberStatus(
             String matchingId, String memberId, MatchingMemberStatus status);
-
-    @Query("{'id': ?0}")
-    @Update("{$set : {'status': ?1}}")
-    Mono<Void> updateMatchingStatus(String id, MatchingStatus status);
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -3,6 +3,8 @@ package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 
+import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
+import org.reactivestreams.Publisher;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.data.mongodb.repository.Update;
@@ -22,4 +24,8 @@ public interface MatchingRepository extends ReactiveMongoRepository<Matching, St
     @Update("{$set : {'members.$.status': ?2}}")
     Mono<Void> updateMatchingMemberStatus(
             String matchingId, String memberId, MatchingMemberStatus status);
+
+    @Query("{'id': ?0}")
+    @Update("{$set : {'status': ?1}}")
+    Mono<Void> updateMatchingStatus(String id, MatchingStatus status);
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -2,9 +2,8 @@ package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
-
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
-import org.reactivestreams.Publisher;
+
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.data.mongodb.repository.Update;

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -40,7 +40,7 @@ public class MatchingService {
                 .subscribe();
     }
 
-    private Function<Matching, Publisher<? extends Matching>> toCancelAndSave() {
+    private Function<Matching, Publisher<Matching>> toCancelAndSave() {
         return matching -> {
             matching.cancel();
             return matchingRepository.save(matching);
@@ -76,7 +76,7 @@ public class MatchingService {
                 memberId, MatchingMemberStatus.NO_RESPONSE);
     }
 
-    private Function<Matching, Mono<? extends Matching>> toUpdateMatching(
+    private Function<Matching, Mono<Matching>> toUpdateMatching(
             final boolean isJoin, final String memberId) {
         return matching -> findByMemberIdAndUpdate(isJoin, memberId, matching.getId());
     }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -41,9 +41,11 @@ public class MatchingService {
                 .subscribe();
     }
 
-    private Function<Matching, Publisher<Void>> cancelMatching() {
-        return matching ->
-                matchingRepository.updateMatchingStatus(matching.getId(), MatchingStatus.CANCEL);
+    private Function<Matching, Publisher<Matching>> cancelMatching() {
+        return matching -> {
+            matching.cancel();
+            return matchingRepository.save(matching);
+        };
     }
 
     private Mono<Matching> saveMatchAndSendEvents(List<MatchingMember> members, int distance) {

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -9,7 +9,6 @@ import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
-import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.repository.MatchingRepository;
 
 import org.reactivestreams.Publisher;

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -42,7 +42,8 @@ public class MatchingService {
     }
 
     private Function<Matching, Publisher<Void>> cancelMatching() {
-        return matching -> matchingRepository.updateMatchingStatus(matching.getId(), MatchingStatus.CANCEL);
+        return matching ->
+                matchingRepository.updateMatchingStatus(matching.getId(), MatchingStatus.CANCEL);
     }
 
     private Mono<Matching> saveMatchAndSendEvents(List<MatchingMember> members, int distance) {
@@ -58,8 +59,7 @@ public class MatchingService {
 
     public Mono<Matching> setMemberStatus(
             final Mono<String> member, final MatchingRequest request) {
-        return member
-                .flatMap(memberId -> updateMatchMemberStatus(request, memberId))
+        return member.flatMap(memberId -> updateMatchMemberStatus(request, memberId))
                 .flatMap(this::updateMatchStatus)
                 .doOnSuccess(this::multiCastEvent);
     }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -11,11 +11,13 @@ import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMe
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.repository.MatchingRepository;
 
+import org.reactivestreams.Publisher;
 import org.springframework.stereotype.Service;
 
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.function.Function;
 
 @Service
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
@@ -34,12 +36,15 @@ public class MatchingService {
         memberIds.forEach(matchingSinkHandler::disconnectIfExist);
         matchingRepository
                 .findAllByMembersIdInAndMembersStatus(memberIds, MatchingMemberStatus.NO_RESPONSE)
-                .flatMap(
-                        matching -> {
-                            matching.cancel();
-                            return matchingRepository.save(matching);
-                        })
+                .flatMap(toCancelAndSave())
                 .subscribe();
+    }
+
+    private Function<Matching, Publisher<? extends Matching>> toCancelAndSave() {
+        return matching -> {
+            matching.cancel();
+            return matchingRepository.save(matching);
+        };
     }
 
     private Mono<Matching> saveMatchAndSendEvents(List<MatchingMember> members, int distance) {
@@ -47,50 +52,57 @@ public class MatchingService {
                 .save(new Matching(members, distance))
                 .doOnSuccess(
                         match ->
-                                members.forEach(
-                                        member -> {
-                                            matchingSinkHandler.create(member.getId());
-                                            matchingSinkHandler.sendEvent(
-                                                    member.getId(), new MatchEvent(match));
-                                        }));
+                                members.forEach(member ->
+                                        createSink(match, member)));
+    }
+
+    private void createSink(final Matching match, final MatchingMember member) {
+        matchingSinkHandler.create(member.getId());
+        matchingSinkHandler.sendEvent(
+                member.getId(), new MatchEvent(match));
     }
 
     public Mono<Matching> setMemberStatus(
             final Mono<String> member, final MatchingRequest request) {
-        return member.flatMap(
-                        mid ->
-                                matchingRepository
-                                        .findByMembersIdAndMembersStatus(
-                                                mid, MatchingMemberStatus.NO_RESPONSE)
-                                        .flatMap(
-                                                match ->
-                                                        matchingRepository
-                                                                .updateMatchingMemberStatus(
-                                                                        match.getId(),
-                                                                        mid,
-                                                                        MatchingMemberStatus
-                                                                                .getByIsJoin(
-                                                                                        request
-                                                                                                .isJoin()))
-                                                                .then(
-                                                                        Mono.defer(
-                                                                                () ->
-                                                                                        matchingRepository
-                                                                                                .findById(
-                                                                                                        match
-                                                                                                                .getId())))))
-                .flatMap(
-                        match -> {
-                            match.updateStatus();
-                            if (!match.isWait()) {
-                                return matchingRepository.save(match);
-                            }
-                            return Mono.just(match);
-                        })
-                .doOnSuccess(this::sendEvent);
+        return member.flatMap(memberId -> updateMatchMemberStatus(request, memberId))
+                .flatMap(this::updateMatchStatus)
+                .doOnSuccess(this::multiCastEvent);
     }
 
-    private void sendEvent(final Matching matching) {
+    private Mono<Matching> updateMatchMemberStatus(final MatchingRequest request, final String memberId) {
+        return findMatchingByNoResponseMember(memberId)
+                .flatMap(toUpdateMatching(request.isJoin(), memberId));
+    }
+
+    private Mono<Matching> findMatchingByNoResponseMember(final String memberId) {
+        return matchingRepository
+                .findByMembersIdAndMembersStatus(
+                        memberId, MatchingMemberStatus.NO_RESPONSE);
+    }
+
+    private Function<Matching, Mono<? extends Matching>> toUpdateMatching(final boolean isJoin, final String memberId) {
+        return matching -> findByMemberIdAndUpdate(isJoin, memberId, matching.getId());
+    }
+    private Mono<Matching> findByMemberIdAndUpdate(final boolean isJoin, final String memberId, final String matchingId) {
+        return matchingRepository
+                .updateMatchingMemberStatus(
+                        matchingId,
+                        memberId,
+                        MatchingMemberStatus
+                                .getByIsJoin(isJoin))
+                .then(Mono.defer(
+                        () -> matchingRepository.findById(matchingId)));
+    }
+
+    private Mono<Matching> updateMatchStatus(final Matching match) {
+        match.updateStatus();
+        if (!match.isWait()) {
+            return matchingRepository.save(match);
+        }
+        return Mono.just(match);
+    }
+
+    private void multiCastEvent(final Matching matching) {
         matching.getMembers()
                 .forEach(
                         member ->


### PR DESCRIPTION
## 변경 사항

기존에 matching service 로직 중 메서드 부분이 너무 길이가 길어 가독성이 떨어지는 문제가 있었습니다. 메서드 추출을 통해 한 메서드 길이를 단축하여 한 메서드가 한 기능을 위주로 가지게 하여 가독성 및 재사용성을 높이기위해 다음과 같이 리펙터링 진행했습니다.