### PR TITLE
refactor : waitingQueue, matchingSerivce 부분 리펙터링

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -17,7 +17,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.function.Function;
 
 @Service
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
@@ -28,8 +27,7 @@ public class MatchingService {
 
     public Mono<Matching> create(final List<String> memberIds, final int distance) {
         final List<MatchingMember> members = memberIds.stream().map(MatchingMember::new).toList();
-        return disconnectLeftMember(memberIds)
-                .then(saveMatchAndSendEvents(members, distance));
+        return disconnectLeftMember(memberIds).then(saveMatchAndSendEvents(members, distance));
     }
 
     private Mono<Void> disconnectLeftMember(List<String> memberIds) {
@@ -40,7 +38,6 @@ public class MatchingService {
                 .flatMap(matchingRepository::save)
                 .then();
     }
-
 
     private Mono<Matching> saveMatchAndSendEvents(List<MatchingMember> members, int distance) {
         return matchingRepository
@@ -60,10 +57,10 @@ public class MatchingService {
                 .doOnSuccess(this::multiCastEvent);
     }
 
-    private Mono<Matching> updateMatchingMemberStatus(final MatchingRequest request, final String memberId) {
+    private Mono<Matching> updateMatchingMemberStatus(
+            final MatchingRequest request, final String memberId) {
         return findMatchingByNoResponseMember(memberId)
-                .flatMap(matching ->
-                        updateMatching(request.isJoin(), memberId, matching.getId()));
+                .flatMap(matching -> updateMatching(request.isJoin(), memberId, matching.getId()));
     }
 
     private Mono<Matching> findMatchingByNoResponseMember(final String memberId) {
@@ -71,8 +68,11 @@ public class MatchingService {
                 memberId, MatchingMemberStatus.NO_RESPONSE);
     }
 
-    private Mono<Matching> updateMatching(final boolean isJoin, final String memberId, final String matchingId) {
-        return matchingRepository.updateMatchingMemberStatus(matchingId, memberId, MatchingMemberStatus.getByIsJoin(isJoin))
+    private Mono<Matching> updateMatching(
+            final boolean isJoin, final String memberId, final String matchingId) {
+        return matchingRepository
+                .updateMatchingMemberStatus(
+                        matchingId, memberId, MatchingMemberStatus.getByIsJoin(isJoin))
                 .then(Mono.defer(() -> matchingRepository.findById(matchingId)));
     }
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/queue/InMemoryWaitingQueue.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/queue/InMemoryWaitingQueue.java
@@ -40,13 +40,13 @@ public class InMemoryWaitingQueue implements WaitingQueue {
     }
 
     @Override
-    public boolean satisfyCount(final RunningDistance distance) {
+    public boolean isSatisfyCount(final RunningDistance distance) {
         return map.get(distance).size() >= SATISFY_COUNT;
     }
 
     @Override
     public List<String> poll(final RunningDistance distance) {
-        if (!satisfyCount(distance)) {
+        if (!isSatisfyCount(distance)) {
             throw new NotSatisfyCountException();
         }
         return IntStream.range(0, SATISFY_COUNT).mapToObj(i -> map.get(distance).poll()).toList();

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/queue/WaitingQueue.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/queue/WaitingQueue.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface WaitingQueue {
     void add(WaitingMember user);
 
-    boolean satisfyCount(RunningDistance distance);
+    boolean isSatisfyCount(RunningDistance distance);
 
     List<String> poll(RunningDistance distance);
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingMessageListener.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingMessageListener.java
@@ -41,7 +41,7 @@ public class WaitingMessageListener implements MessageListener {
         Arrays.stream(RunningDistance.values())
                 .forEach(
                         distance -> {
-                            if (queue.satisfyCount(distance)) {
+                            if (queue.isSatisfyCount(distance)) {
                                 List<String> members = queue.poll(distance);
                                 matchingService.create(members, distance.getMeter()).subscribe();
                                 eventService.sendMatchEvent(members);

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/queue/InMemoryWaitingQueueTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/queue/InMemoryWaitingQueueTest.java
@@ -20,9 +20,9 @@ class InMemoryWaitingQueueTest {
     @DisplayName("큐에 추가를 수행한 후 개수가 만족한 지 확인한다")
     void runAdd() {
         waitingQueue.add(현준);
-        assertThat(waitingQueue.satisfyCount(현준.distance())).isFalse();
+        assertThat(waitingQueue.isSatisfyCount(현준.distance())).isFalse();
         waitingQueue.add(성우);
-        assertThat(waitingQueue.satisfyCount(현준.distance())).isTrue();
+        assertThat(waitingQueue.isSatisfyCount(현준.distance())).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## 변경 사항
- waitingQueue 에서 statisfyCount -> isSatisfyCount로 변경하였습니다.
- matchingService 부분에 flatmap에 혼용하는 일부 로직 doOnNext로 분리하였습니다.
-  가독성을 위해 Function 리턴 보다는 Reactor 형 리턴으로 통일하였습니다. 
- matchingService create 로직을 한 파이프라인으로 돌도록 변경하였습니다. 
