### PR TITLE
feat : matching/waiting에서 무응답한 SSE Sink 주기적으로 삭제 #PAR-189

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
@@ -10,6 +10,7 @@ import online.partyrun.partyrunmatchingservice.domain.matching.exception.Invalid
 
 import org.springframework.data.annotation.Id;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -18,16 +19,19 @@ import java.util.Objects;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Matching {
     private static final int MIN_DISTANCE = 1;
+    private static final int TIMEOUT_HOUR = 2;
     @Id String id;
     List<MatchingMember> members;
     int distance;
     MatchingStatus status = MatchingStatus.WAIT;
+    LocalDateTime startAt;
 
-    public Matching(final List<MatchingMember> members, int distance) {
+    public Matching(final List<MatchingMember> members, int distance, LocalDateTime startAt) {
         validateMembers(members);
         validateDistance(distance);
         this.members = members;
         this.distance = distance;
+        this.startAt = startAt;
     }
 
     private void validateDistance(int distance) {
@@ -63,5 +67,9 @@ public class Matching {
             return MatchingStatus.SUCCESS;
         }
         return MatchingStatus.WAIT;
+    }
+
+    public boolean isTimeOut(LocalDateTime now) {
+        return this.startAt.isBefore(now.minusHours(TIMEOUT_HOUR));
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -3,6 +3,7 @@ package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 
+import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.data.mongodb.repository.Update;
@@ -22,4 +23,6 @@ public interface MatchingRepository extends ReactiveMongoRepository<Matching, St
     @Update("{$set : {'members.$.status': ?2}}")
     Mono<Void> updateMatchingMemberStatus(
             String matchingId, String memberId, MatchingMemberStatus status);
+
+    Flux<Matching> findAllByStatus(MatchingStatus status);
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -2,8 +2,8 @@ package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
-
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
+
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.data.mongodb.repository.Update;

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -12,7 +12,6 @@ import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMe
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.repository.MatchingRepository;
 
-import org.reactivestreams.Publisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -9,14 +9,18 @@ import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
+import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.repository.MatchingRepository;
 
 import org.reactivestreams.Publisher;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.function.Function;
 
@@ -24,8 +28,10 @@ import java.util.function.Function;
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 @RequiredArgsConstructor
 public class MatchingService {
+    private static final int REMOVE_SINK_SCHEDULE_TIME = 3_600_000; // 3시간 마다 실행
     MatchingRepository matchingRepository;
     MatchingSinkHandler matchingSinkHandler;
+    Clock clock;
 
     public Mono<Matching> create(final List<String> memberIds, final int distance) {
         final List<MatchingMember> members = memberIds.stream().map(MatchingMember::new).toList();
@@ -50,7 +56,7 @@ public class MatchingService {
 
     private Mono<Matching> saveMatchAndSendEvents(List<MatchingMember> members, int distance) {
         return matchingRepository
-                .save(new Matching(members, distance))
+                .save(new Matching(members, distance, LocalDateTime.now(clock)))
                 .doOnSuccess(match -> members.forEach(member -> createSink(match, member)));
     }
 
@@ -117,5 +123,21 @@ public class MatchingService {
                                                 matchingSinkHandler.complete(id);
                                             }
                                         }));
+    }
+
+    @Scheduled(fixedDelay = REMOVE_SINK_SCHEDULE_TIME)
+    public void removeUnConnectedSink() {
+        matchingRepository
+                .findAllByStatus(MatchingStatus.WAIT)
+                .filter(matching -> matching.isTimeOut(LocalDateTime.now(clock)))
+                .doOnNext(Matching::cancel)
+                .doOnNext(this::disconnectAllMember)
+                .flatMap(matchingRepository::save)
+                .subscribe();
+    }
+
+    private void disconnectAllMember(Matching matching) {
+        matching.getMembers()
+                .forEach(member -> matchingSinkHandler.disconnectIfExist(member.getId()));
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/queue/InMemoryWaitingQueue.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/queue/InMemoryWaitingQueue.java
@@ -51,4 +51,11 @@ public class InMemoryWaitingQueue implements WaitingQueue {
         }
         return IntStream.range(0, SATISFY_COUNT).mapToObj(i -> map.get(distance).poll()).toList();
     }
+
+    @Override
+    public boolean hasMember(String userId) {
+        return Arrays.stream(RunningDistance.values())
+                .map(map::get)
+                .anyMatch(q -> q.contains(userId));
+    }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/queue/WaitingQueue.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/queue/WaitingQueue.java
@@ -6,9 +6,11 @@ import online.partyrun.partyrunmatchingservice.domain.waiting.root.WaitingMember
 import java.util.List;
 
 public interface WaitingQueue {
-    void add(WaitingMember user);
+    void add(WaitingMember member);
 
     boolean satisfyCount(RunningDistance distance);
 
     List<String> poll(RunningDistance distance);
+
+    boolean hasMember(String userId);
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
@@ -7,8 +7,8 @@ import lombok.experimental.FieldDefaults;
 import online.partyrun.partyrunmatchingservice.domain.matching.controller.MatchingRequest;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
-
 import online.partyrun.partyrunmatchingservice.domain.waiting.queue.WaitingQueue;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -55,10 +55,12 @@ public class WaitingEventService {
     public void removeUnConnectedSink() {
         waitingSinkHandler.getConnectors().stream()
                 .filter(connect -> !waitingQueue.hasMember(connect))
-                .forEach(key -> {
-                    waitingSinkHandler.disconnectIfExist(key);
-                    matchingService.setMemberStatus(Mono.just(key), new MatchingRequest(false)).subscribe();
-                });
-
+                .forEach(
+                        key -> {
+                            waitingSinkHandler.disconnectIfExist(key);
+                            matchingService
+                                    .setMemberStatus(Mono.just(key), new MatchingRequest(false))
+                                    .subscribe();
+                        });
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
@@ -4,8 +4,12 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
+import online.partyrun.partyrunmatchingservice.domain.matching.controller.MatchingRequest;
+import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
 
+import online.partyrun.partyrunmatchingservice.domain.waiting.queue.WaitingQueue;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import reactor.core.publisher.Flux;
@@ -17,7 +21,10 @@ import java.util.List;
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 @RequiredArgsConstructor
 public class WaitingEventService {
+    private static final int REMOVE_SINK_SCHEDULE_TIME = 14_400_000; // 12시간 마다 실행
     WaitingSinkHandler waitingSinkHandler;
+    WaitingQueue waitingQueue;
+    MatchingService matchingService;
 
     public void register(final String id) {
         waitingSinkHandler.create(id);
@@ -42,5 +49,16 @@ public class WaitingEventService {
 
     public void sendMatchEvent(List<String> members) {
         members.forEach(member -> waitingSinkHandler.sendEvent(member, WaitingStatus.MATCHED));
+    }
+
+    @Scheduled(fixedDelay = REMOVE_SINK_SCHEDULE_TIME) // 12시간 마다 실행
+    public void removeUnConnectedSink() {
+        waitingSinkHandler.getConnectors().stream()
+                .filter(connect -> !waitingQueue.hasMember(connect))
+                .forEach(key -> {
+                    waitingSinkHandler.disconnectIfExist(key);
+                    matchingService.setMemberStatus(Mono.just(key), new MatchingRequest(false)).subscribe();
+                });
+
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingMessageListener.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingMessageListener.java
@@ -48,4 +48,5 @@ public class WaitingMessageListener implements MessageListener {
                             }
                         });
     }
+
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingMessageListener.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingMessageListener.java
@@ -48,5 +48,4 @@ public class WaitingMessageListener implements MessageListener {
                             }
                         });
     }
-
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingService.java
@@ -3,11 +3,14 @@ package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.CreateWaitingRequest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.message.WaitingMessagePublisher;
 import online.partyrun.partyrunmatchingservice.domain.waiting.root.WaitingMember;
 import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
+
 import org.springframework.stereotype.Service;
+
 import reactor.core.publisher.Mono;
 
 @Service

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingService.java
@@ -3,21 +3,17 @@ package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.CreateWaitingRequest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.message.WaitingMessagePublisher;
 import online.partyrun.partyrunmatchingservice.domain.waiting.root.WaitingMember;
 import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
-
 import org.springframework.stereotype.Service;
-
 import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class WaitingService {
-
     WaitingEventService eventService;
     WaitingMessagePublisher messagePublisher;
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/config/ScheduleConfig.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/config/ScheduleConfig.java
@@ -1,0 +1,8 @@
+package online.partyrun.partyrunmatchingservice.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class ScheduleConfig {}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/config/TimeConfig.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/config/TimeConfig.java
@@ -1,0 +1,14 @@
+package online.partyrun.partyrunmatchingservice.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class TimeConfig {
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
@@ -1,25 +1,27 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @ContextConfiguration(classes = MatchingController.class)
 @DisplayName("MatchingController")
@@ -27,7 +29,10 @@ import static org.springframework.restdocs.webtestclient.WebTestClientRestDocume
 class MatchingControllerTest extends WebfluxDocsTest {
     @MockBean MatchingService matchingService;
     final Matching matching =
-            new Matching(List.of(new MatchingMember("현준"), new MatchingMember("준혁")), 1000, LocalDateTime.now());
+            new Matching(
+                    List.of(new MatchingMember("현준"), new MatchingMember("준혁")),
+                    1000,
+                    LocalDateTime.now());
 
     @Test
     @DisplayName("post : match 수락 여부 전송")

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
@@ -1,26 +1,25 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @ContextConfiguration(classes = MatchingController.class)
 @DisplayName("MatchingController")
@@ -28,7 +27,7 @@ import java.util.List;
 class MatchingControllerTest extends WebfluxDocsTest {
     @MockBean MatchingService matchingService;
     final Matching matching =
-            new Matching(List.of(new MatchingMember("현준"), new MatchingMember("준혁")), 1000);
+            new Matching(List.of(new MatchingMember("현준"), new MatchingMember("준혁")), 1000, LocalDateTime.now());
 
     @Test
     @DisplayName("post : match 수락 여부 전송")

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
@@ -1,7 +1,10 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.entity;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidDistanceException;
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidMembersException;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -10,16 +13,15 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 @DisplayName("Matching")
 class MatchingTest {
-    LocalDateTime now =  LocalDateTime.now();
+    LocalDateTime now = LocalDateTime.now();
+
     @ParameterizedTest
     @NullAndEmptySource
     @DisplayName("matching 생성 시 members가 null이거나 empty 에외를 반환한다.")
     void throwInvalidMember(List<MatchingMember> members) {
-        assertThatThrownBy(() -> new Matching(members, 1000,now))
+        assertThatThrownBy(() -> new Matching(members, 1000, now))
                 .isInstanceOf(InvalidMembersException.class);
     }
 

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
@@ -1,25 +1,25 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.entity;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidDistanceException;
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidMembersException;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Matching")
 class MatchingTest {
-
+    LocalDateTime now =  LocalDateTime.now();
     @ParameterizedTest
     @NullAndEmptySource
     @DisplayName("matching 생성 시 members가 null이거나 empty 에외를 반환한다.")
     void throwInvalidMember(List<MatchingMember> members) {
-        assertThatThrownBy(() -> new Matching(members, 1000))
+        assertThatThrownBy(() -> new Matching(members, 1000,now))
                 .isInstanceOf(InvalidMembersException.class);
     }
 
@@ -27,7 +27,7 @@ class MatchingTest {
     @ValueSource(ints = {0, -1, -100})
     @DisplayName("matching 생성 시 거리가 0 이하면 예외를 반환한다")
     void throwInvalidMember(int distance) {
-        assertThatThrownBy(() -> new Matching(List.of(new MatchingMember("현준")), distance))
+        assertThatThrownBy(() -> new Matching(List.of(new MatchingMember("현준")), distance, now))
                 .isInstanceOf(InvalidDistanceException.class);
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
@@ -1,27 +1,29 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+
 import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @DataMongoTest
 @DisplayName("MatchingRepository")
 class MatchingRepositoryTest {
     @Autowired MatchingRepository matchRepository;
-    LocalDateTime now =  LocalDateTime.now();
+    LocalDateTime now = LocalDateTime.now();
     List<MatchingMember> members =
             Stream.of("user1", "user2", "user3").map(MatchingMember::new).toList();
 
@@ -33,7 +35,7 @@ class MatchingRepositoryTest {
     @Test
     @DisplayName("생성을 수행한다")
     void runSave() {
-        Matching match = new Matching(members, 1000,now);
+        Matching match = new Matching(members, 1000, now);
 
         StepVerifier.create(matchRepository.save(match))
                 .assertNext(

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
@@ -1,27 +1,27 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-
 import reactor.test.StepVerifier;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataMongoTest
 @DisplayName("MatchingRepository")
 class MatchingRepositoryTest {
     @Autowired MatchingRepository matchRepository;
+    LocalDateTime now =  LocalDateTime.now();
     List<MatchingMember> members =
             Stream.of("user1", "user2", "user3").map(MatchingMember::new).toList();
 
@@ -33,7 +33,7 @@ class MatchingRepositoryTest {
     @Test
     @DisplayName("생성을 수행한다")
     void runSave() {
-        Matching match = new Matching(members, 1000);
+        Matching match = new Matching(members, 1000,now);
 
         StepVerifier.create(matchRepository.save(match))
                 .assertNext(
@@ -50,16 +50,16 @@ class MatchingRepositoryTest {
     @Test
     @DisplayName("전채 조회를 수행한다")
     void runFindAll() {
-        matchRepository.save(new Matching(members, 1000)).block();
-        matchRepository.save(new Matching(members, 1000)).block();
-        matchRepository.save(new Matching(members, 1000)).block();
+        matchRepository.save(new Matching(members, 1000, now)).block();
+        matchRepository.save(new Matching(members, 1000, now)).block();
+        matchRepository.save(new Matching(members, 1000, now)).block();
         StepVerifier.create(matchRepository.findAll()).expectNextCount(3).verifyComplete();
     }
 
     @Test
     @DisplayName("matching member 상태를 변경한다")
     void updateMatchingMemberStatus() {
-        final Matching matching = matchRepository.save(new Matching(members, 1000)).block();
+        final Matching matching = matchRepository.save(new Matching(members, 1000, now)).block();
 
         matchRepository
                 .updateMatchingMemberStatus(

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
@@ -1,18 +1,18 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @DisplayName("WaitingEventService")
-@SpringBootTest(classes = {WaitingEventService.class, WaitingSinkHandler.class})
+@SpringBootTest
 class WaitingEventServiceTest {
     @Autowired WaitingEventService waitingEventService;
     @Autowired WaitingSinkHandler waitingSinkHandler;
@@ -51,5 +51,15 @@ class WaitingEventServiceTest {
                                     .expectNext(WaitingStatus.MATCHED, WaitingStatus.CONNECTED)
                                     .verifyComplete());
         }
+    }
+
+    @Test
+    @DisplayName("timeout된 sink를 삭제한다")
+    void runDeleteSink() {
+
+        waitingSinkHandler.create("현준");
+        waitingEventService.removeUnConnectedSink();
+
+        assertThat(waitingSinkHandler.getConnectors()).doesNotContain("현준");
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
@@ -1,15 +1,17 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("WaitingEventService")
 @SpringBootTest


### PR DESCRIPTION
## 변경 사항
- Matching 에 Timeout 판단 추가
- MatchingRepository에 Status별 findAll 추가
- MatchingService에 주기적으로 스케줄러를 동작하여 잔여 Sink를 삭제
- WaitingQueue에서 해당 맴버 포함 여부를 확인 가능
- Schedule 및 Clock Config 추가

## 알아야할 사항
- MatchingService 스케줄러가 비동기로 동작하여 테스트 코드 내 Delay를 설정하였습니다.
- WaitingService와 WaitingEventService의 관심사가 비슷하여 추후 두 서비스 병합을 고려하는 부분도 논의가 필요해보입니다.