### PR TITLE
feat : controller advice 설정 

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -14,12 +14,12 @@ operation::create-waiting[snippets='http-request,http-response']
 
 operation::get-waiting-event[snippets='http-request,http-response']
 
+=== waiting distance 값이 잘못 됨
+
+operation::create-waiting-throw-distance-was-bad-value[snippets='http-request,http-response']
+
 == Matching
 
 === Matching 수락/거절 전송
 
 operation::create-matching[snippets='http-request,http-response']
-
-=== matching event stream 요청
-
-operation::get-matching-event[snippets='http-request,http-response']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -23,3 +23,7 @@ operation::create-waiting-throw-distance-was-bad-value[snippets='http-request,ht
 === Matching 수락/거절 전송
 
 operation::create-matching[snippets='http-request,http-response']
+
+=== matching event stream 요청
+
+operation::get-matching-event[snippets='http-request,http-response']

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
-import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidMembersException;
+import online.partyrun.partyrunmatchingservice.domain.matching.exception.NotExistMembersException;
 import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
 
 import org.springframework.data.annotation.Id;
@@ -38,7 +38,7 @@ public class Matching {
 
     private void validateMembers(List<MatchingMember> members) {
         if (Objects.isNull(members) || members.isEmpty()) {
-            throw new InvalidMembersException();
+            throw new NotExistMembersException();
         }
     }
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
-import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidDistanceException;
+import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidMembersException;
 
 import org.springframework.data.annotation.Id;
@@ -32,7 +32,7 @@ public class Matching {
 
     private void validateDistance(int distance) {
         if (distance < MIN_DISTANCE) {
-            throw new InvalidDistanceException();
+            throw new InvalidDistanceException(distance);
         }
     }
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
-import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidMembersException;
+import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
 
 import org.springframework.data.annotation.Id;
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMember.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMember.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
-import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidIdException;
+import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidMatchingIdException;
 
 import java.util.Objects;
 
@@ -25,7 +25,7 @@ public class MatchingMember {
 
     private void validateId(String id) {
         if (Objects.isNull(id) || id.isEmpty()) {
-            throw new InvalidIdException(id);
+            throw new InvalidMatchingIdException(id);
         }
     }
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMember.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMember.java
@@ -25,7 +25,7 @@ public class MatchingMember {
 
     private void validateId(String id) {
         if (Objects.isNull(id) || id.isEmpty()) {
-            throw new InvalidIdException();
+            throw new InvalidIdException(id);
         }
     }
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/exception/InvalidDistanceException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/exception/InvalidDistanceException.java
@@ -1,3 +1,0 @@
-package online.partyrun.partyrunmatchingservice.domain.matching.exception;
-
-public class InvalidDistanceException extends IllegalArgumentException {}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/exception/InvalidIdException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/exception/InvalidIdException.java
@@ -1,3 +1,9 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.exception;
 
-public class InvalidIdException extends IllegalArgumentException {}
+import online.partyrun.partyrunmatchingservice.global.exception.BadRequestException;
+
+public class InvalidIdException extends BadRequestException {
+    public InvalidIdException(String id) {
+        super(id + "는 잘못된 ID입니다.");
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/exception/InvalidMatchingIdException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/exception/InvalidMatchingIdException.java
@@ -2,8 +2,8 @@ package online.partyrun.partyrunmatchingservice.domain.matching.exception;
 
 import online.partyrun.partyrunmatchingservice.global.exception.BadRequestException;
 
-public class InvalidIdException extends BadRequestException {
-    public InvalidIdException(String id) {
+public class InvalidMatchingIdException extends BadRequestException {
+    public InvalidMatchingIdException(String id) {
         super(id + "는 잘못된 ID입니다.");
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/exception/InvalidMembersException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/exception/InvalidMembersException.java
@@ -1,3 +1,9 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.exception;
 
-public class InvalidMembersException extends IllegalArgumentException {}
+import online.partyrun.partyrunmatchingservice.global.exception.BadRequestException;
+
+public class InvalidMembersException extends BadRequestException {
+    public InvalidMembersException() {
+        super("참여자 정보가 잘못되었습니다.");
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/exception/NotExistMembersException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/exception/NotExistMembersException.java
@@ -2,8 +2,8 @@ package online.partyrun.partyrunmatchingservice.domain.matching.exception;
 
 import online.partyrun.partyrunmatchingservice.global.exception.BadRequestException;
 
-public class InvalidMembersException extends BadRequestException {
-    public InvalidMembersException() {
-        super("참여자 정보가 잘못되었습니다.");
+public class NotExistMembersException extends BadRequestException {
+    public NotExistMembersException() {
+        super("참여자 정보가 비어있습니다");
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/exception/DuplicateMemberException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/exception/DuplicateMemberException.java
@@ -1,7 +1,9 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.exception;
 
-public class DuplicateMemberException extends IllegalArgumentException {
+import online.partyrun.partyrunmatchingservice.global.exception.BadRequestException;
+
+public class DuplicateMemberException extends BadRequestException {
     public DuplicateMemberException(String memberId) {
-        super(memberId + "was duplicated");
+        super(memberId + "는 중복되었습니다.");
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/exception/InvalidDistanceException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/exception/InvalidDistanceException.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunmatchingservice.domain.waiting.exception;
+
+import online.partyrun.partyrunmatchingservice.global.exception.BadRequestException;
+
+public class InvalidDistanceException extends BadRequestException {
+    public InvalidDistanceException(int distance) {
+        super(distance + " 는 허용하지 않는 거리입니다.");
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/exception/NotAllowDistanceException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/exception/NotAllowDistanceException.java
@@ -1,7 +1,0 @@
-package online.partyrun.partyrunmatchingservice.domain.waiting.exception;
-
-public class NotAllowDistanceException extends IllegalArgumentException {
-    public NotAllowDistanceException(int meter) {
-        super(meter + "는 허용하지 않은 거리입니다.");
-    }
-}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/exception/NotSatisfyCountException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/exception/NotSatisfyCountException.java
@@ -1,3 +1,9 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.exception;
 
-public class NotSatisfyCountException extends IllegalArgumentException {}
+import online.partyrun.partyrunmatchingservice.global.exception.BadRequestException;
+
+public class NotSatisfyCountException extends BadRequestException {
+    public NotSatisfyCountException() {
+        super("적정 유저 수가 충족하지 않았습니다.");
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/root/RunningDistance.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/root/RunningDistance.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
 
 import java.util.Arrays;

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/root/RunningDistance.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/root/RunningDistance.java
@@ -4,8 +4,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
-import online.partyrun.partyrunmatchingservice.domain.waiting.exception.NotAllowDistanceException;
+import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
 
 import java.util.Arrays;
 
@@ -24,6 +23,6 @@ public enum RunningDistance {
         return Arrays.stream(RunningDistance.values())
                 .filter(d -> d.meter == meter)
                 .findAny()
-                .orElseThrow(() -> new NotAllowDistanceException(meter));
+                .orElseThrow(() -> new InvalidDistanceException(meter));
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/controller/HttpControllerAdvice.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/controller/HttpControllerAdvice.java
@@ -1,13 +1,16 @@
 package online.partyrun.partyrunmatchingservice.global.controller;
 
 import lombok.extern.slf4j.Slf4j;
+
+import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
 import online.partyrun.partyrunmatchingservice.global.exception.BadRequestException;
 import online.partyrun.partyrunmatchingservice.global.exception.InternalServerException;
-import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
 import reactor.core.publisher.Mono;
 
 @Slf4j

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/controller/HttpControllerAdvice.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/controller/HttpControllerAdvice.java
@@ -1,0 +1,32 @@
+package online.partyrun.partyrunmatchingservice.global.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import online.partyrun.partyrunmatchingservice.global.exception.BadRequestException;
+import online.partyrun.partyrunmatchingservice.global.exception.InternalServerException;
+import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@RestControllerAdvice
+public class HttpControllerAdvice {
+    private static final String BAD_REQUEST_MESSAGE = "잘못된 요청입니다.";
+    private static final String SERVER_ERROR_MESSAGE = "알 수 없는 에러입니다.";
+
+    @ExceptionHandler(BadRequestException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Mono<MessageResponse> handleBadRequestException(BadRequestException exception) {
+        log.warn(exception.getMessage());
+        return Mono.just(new MessageResponse(BAD_REQUEST_MESSAGE));
+    }
+
+    @ExceptionHandler(InternalServerException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public MessageResponse handleInternalServerException(InternalServerException exception) {
+        log.warn(exception.getMessage());
+        return new MessageResponse(SERVER_ERROR_MESSAGE);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/BadRequestException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/BadRequestException.java
@@ -1,0 +1,11 @@
+package online.partyrun.partyrunmatchingservice.global.exception;
+
+public abstract class BadRequestException extends RuntimeException {
+    protected BadRequestException() {
+        super("잘못된 요청입니다.");
+    }
+
+    protected BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/InternalServerException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/InternalServerException.java
@@ -1,11 +1,6 @@
 package online.partyrun.partyrunmatchingservice.global.exception;
 
-/**
- * 알 수 없는 에러가 발생시 사용하는 Exception 클래스입니다.
- *
- * @author parkhyeonjun
- * @since 2023.06.29
- */
+
 public abstract class InternalServerException extends RuntimeException {
     protected InternalServerException() {
         super("알 수 없는 에러입니다.");

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/InternalServerException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/InternalServerException.java
@@ -1,0 +1,17 @@
+package online.partyrun.partyrunmatchingservice.global.exception;
+
+/**
+ * 알 수 없는 에러가 발생시 사용하는 Exception 클래스입니다.
+ *
+ * @author parkhyeonjun
+ * @since 2023.06.29
+ */
+public abstract class InternalServerException extends RuntimeException {
+    protected InternalServerException() {
+        super("알 수 없는 에러입니다.");
+    }
+
+    protected InternalServerException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/InternalServerException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/InternalServerException.java
@@ -1,6 +1,5 @@
 package online.partyrun.partyrunmatchingservice.global.exception;
 
-
 public abstract class InternalServerException extends RuntimeException {
     protected InternalServerException() {
         super("알 수 없는 에러입니다.");

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/InvalidSinksKeyException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/InvalidSinksKeyException.java
@@ -1,0 +1,7 @@
+package online.partyrun.partyrunmatchingservice.global.exception;
+
+public class InvalidSinksKeyException extends BadRequestException {
+    public InvalidSinksKeyException() {
+        super("sinks의 key값이 올바르지 않습니다.");
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/SseConnectionException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/SseConnectionException.java
@@ -1,11 +1,6 @@
 package online.partyrun.partyrunmatchingservice.global.exception;
 
-/**
- * Sse connection 진행 중 애러 발생시 사용하는 exception 입니다.
- *
- * @author parkhyeonjun
- * @since 2023.06.29
- */
+
 public class SseConnectionException extends InternalServerException {
     public SseConnectionException() {
         super("Sse 연결 중 문제가 발생했습니다.");

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/SseConnectionException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/SseConnectionException.java
@@ -1,6 +1,5 @@
 package online.partyrun.partyrunmatchingservice.global.exception;
 
-
 public class SseConnectionException extends InternalServerException {
     public SseConnectionException() {
         super("Sse 연결 중 문제가 발생했습니다.");

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/SseConnectionException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/exception/SseConnectionException.java
@@ -1,0 +1,13 @@
+package online.partyrun.partyrunmatchingservice.global.exception;
+
+/**
+ * Sse connection 진행 중 애러 발생시 사용하는 exception 입니다.
+ *
+ * @author parkhyeonjun
+ * @since 2023.06.29
+ */
+public class SseConnectionException extends InternalServerException {
+    public SseConnectionException() {
+        super("Sse 연결 중 문제가 발생했습니다.");
+    }
+}

--- a/src/test/java/online/partyrun/partyrunmatchingservice/config/docs/WebfluxDocsTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/config/docs/WebfluxDocsTest.java
@@ -1,5 +1,9 @@
 package online.partyrun.partyrunmatchingservice.config.docs;
 
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.documentationConfiguration;
+import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.csrf;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,10 +12,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
-
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.documentationConfiguration;
-import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.csrf;
 
 @WebFluxTest
 @ExtendWith(RestDocumentationExtension.class)

--- a/src/test/java/online/partyrun/partyrunmatchingservice/config/docs/WebfluxDocsTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/config/docs/WebfluxDocsTest.java
@@ -1,9 +1,5 @@
 package online.partyrun.partyrunmatchingservice.config.docs;
 
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.documentationConfiguration;
-import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.csrf;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +8,10 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.documentationConfiguration;
+import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.csrf;
 
 @WebFluxTest
 @ExtendWith(RestDocumentationExtension.class)

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
@@ -1,28 +1,27 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
-
+import online.partyrun.partyrunmatchingservice.global.controller.HttpControllerAdvice;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 
-@ContextConfiguration(classes = MatchingController.class)
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+
+@ContextConfiguration(classes = {MatchingController.class, HttpControllerAdvice.class})
 @DisplayName("MatchingController")
 @WithMockUser
 class MatchingControllerTest extends WebfluxDocsTest {

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
@@ -1,25 +1,27 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
 import online.partyrun.partyrunmatchingservice.global.controller.HttpControllerAdvice;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @ContextConfiguration(classes = {MatchingController.class, HttpControllerAdvice.class})
 @DisplayName("MatchingController")

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMemberTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingMemberTest.java
@@ -3,7 +3,7 @@ package online.partyrun.partyrunmatchingservice.domain.matching.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidIdException;
+import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidMatchingIdException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -16,7 +16,7 @@ class MatchingMemberTest {
     @DisplayName("MatchingMember 생성 시 id가 null이거나 empty면 에외를 반환한다.")
     void throwInvalidMember(String memberId) {
         assertThatThrownBy(() -> new MatchingMember(memberId))
-                .isInstanceOf(InvalidIdException.class);
+                .isInstanceOf(InvalidMatchingIdException.class);
     }
 
     @ParameterizedTest

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
@@ -2,8 +2,8 @@ package online.partyrun.partyrunmatchingservice.domain.matching.entity;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidMembersException;
+import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
@@ -1,10 +1,7 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.entity;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.NotExistMembersException;
 import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -12,6 +9,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Matching")
 class MatchingTest {
@@ -21,7 +20,7 @@ class MatchingTest {
     @NullAndEmptySource
     @DisplayName("matching 생성 시 members가 null이거나 empty 에외를 반환한다.")
     void throwInvalidMember(List<MatchingMember> members) {
-        assertThatThrownBy(() -> new Matching(members, 1000))
+        assertThatThrownBy(() -> new Matching(members, 1000, LocalDateTime.now()))
                 .isInstanceOf(NotExistMembersException.class);
     }
 

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
@@ -2,7 +2,7 @@ package online.partyrun.partyrunmatchingservice.domain.matching.entity;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidMembersException;
+import online.partyrun.partyrunmatchingservice.domain.matching.exception.NotExistMembersException;
 import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
 
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +20,7 @@ class MatchingTest {
     @DisplayName("matching 생성 시 members가 null이거나 empty 에외를 반환한다.")
     void throwInvalidMember(List<MatchingMember> members) {
         assertThatThrownBy(() -> new Matching(members, 1000))
-                .isInstanceOf(InvalidMembersException.class);
+                .isInstanceOf(NotExistMembersException.class);
     }
 
     @ParameterizedTest

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
@@ -1,7 +1,10 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.entity;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.NotExistMembersException;
 import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -9,8 +12,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Matching")
 class MatchingTest {

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/MatchingTest.java
@@ -2,7 +2,7 @@ package online.partyrun.partyrunmatchingservice.domain.matching.entity;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidDistanceException;
+import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
 import online.partyrun.partyrunmatchingservice.domain.matching.exception.InvalidMembersException;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
@@ -1,32 +1,34 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.CreateWaitingRequest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
+import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
 import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingEventService;
 import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingService;
+import online.partyrun.partyrunmatchingservice.global.controller.HttpControllerAdvice;
 import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-@ContextConfiguration(classes = WaitingController.class)
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+
+@ContextConfiguration(classes = {WaitingController.class, HttpControllerAdvice.class})
 @WithMockUser
 @DisplayName("WaitingController")
 class WaitingControllerTest extends WebfluxDocsTest {
-    @MockBean WaitingService waitingService;
-    @MockBean WaitingEventService waitingEventService;
+    @MockBean
+    WaitingService waitingService;
+    @MockBean
+    WaitingEventService waitingEventService;
 
     @Test
     @DisplayName("post : waiting 생성 요청")
@@ -63,4 +65,25 @@ class WaitingControllerTest extends WebfluxDocsTest {
                 .expectBody()
                 .consumeWith(document("get-waiting-event"));
     }
+
+
+    @Test
+    @DisplayName("distance값을_적절하게_요청하지_않으면_예외을 반환한다")
+    void throwException() {
+        final int distance = 100;
+        given(waitingService.create(any(Mono.class), any(CreateWaitingRequest.class)))
+                .willThrow(new InvalidDistanceException(distance));
+
+        final CreateWaitingRequest request = new CreateWaitingRequest(distance);
+        client.post()
+                .uri("/waiting")
+                .bodyValue(request)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isBadRequest()
+                .expectBody()
+                .consumeWith(document("create-waiting-throw-distance-was-bad-value"));
+    }
+
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
@@ -1,5 +1,9 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.CreateWaitingRequest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
@@ -8,27 +12,23 @@ import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingEve
 import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingService;
 import online.partyrun.partyrunmatchingservice.global.controller.HttpControllerAdvice;
 import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @ContextConfiguration(classes = {WaitingController.class, HttpControllerAdvice.class})
 @WithMockUser
 @DisplayName("WaitingController")
 class WaitingControllerTest extends WebfluxDocsTest {
-    @MockBean
-    WaitingService waitingService;
-    @MockBean
-    WaitingEventService waitingEventService;
+    @MockBean WaitingService waitingService;
+    @MockBean WaitingEventService waitingEventService;
 
     @Test
     @DisplayName("post : waiting 생성 요청")
@@ -66,7 +66,6 @@ class WaitingControllerTest extends WebfluxDocsTest {
                 .consumeWith(document("get-waiting-event"));
     }
 
-
     @Test
     @DisplayName("distance값을_적절하게_요청하지_않으면_예외을 반환한다")
     void throwException() {
@@ -85,5 +84,4 @@ class WaitingControllerTest extends WebfluxDocsTest {
                 .expectBody()
                 .consumeWith(document("create-waiting-throw-distance-was-bad-value"));
     }
-
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/root/RunningDistanceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/root/RunningDistanceTest.java
@@ -1,10 +1,6 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.root;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import online.partyrun.partyrunmatchingservice.domain.waiting.exception.NotAllowDistanceException;
-
+import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -12,6 +8,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("RunningDistance")
 class RunningDistanceTest {
@@ -34,6 +33,6 @@ class RunningDistanceTest {
     @DisplayName("허용하지 않은 숫자를 입력하면 예외를 반환한다")
     void throwNotAllowDistanceException() {
         assertThatThrownBy(() -> RunningDistance.getBy(2500))
-                .isInstanceOf(NotAllowDistanceException.class);
+                .isInstanceOf(InvalidDistanceException.class);
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/root/RunningDistanceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/root/RunningDistanceTest.java
@@ -1,6 +1,10 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.root;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import online.partyrun.partyrunmatchingservice.domain.waiting.exception.InvalidDistanceException;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -8,9 +12,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("RunningDistance")
 class RunningDistanceTest {


### PR DESCRIPTION
## 변경 사항
- InvalidDistanceException, NotAllowDistanceException 통합
- Http status 별 abstract controller 구현
- 각 예외 클래스를 http Status 별 클래스를 상속받음
- Controller Advice 추가 
## 알아야할 사항
기존에는 예외 발생 시 클라이언트에게 별도 메시지를 전달하는 부분이 없었습니다. 또한, 에러 로그를 그대로 전송하여 보안에 치명적인 문제를 제공하였습니다. 해당 부분을 보완하기 위해 Controller Advice를 적용하고, 각 Exception을 Http status 수준으로 추상/구체화를 진행했습니다.

