### PR TITLE
fix : change waiting-event response format

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingController.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingController.java
@@ -1,21 +1,17 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.controller;
 
 import jakarta.validation.Valid;
-
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.CreateWaitingRequest;
-import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
+import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventResponse;
 import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingEventService;
 import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingService;
 import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -38,7 +34,7 @@ public class WaitingController {
 
     @GetMapping(path = "event", produces = "text/event-stream")
     @ResponseStatus(HttpStatus.OK)
-    public Flux<WaitingStatus> getEventSteam(Mono<Authentication> auth) {
+    public Flux<WaitingEventResponse> getEventSteam(Mono<Authentication> auth) {
         return this.waitingEventService.getEventStream(auth.map(Principal::getName));
     }
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingController.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingController.java
@@ -1,17 +1,21 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.controller;
 
 import jakarta.validation.Valid;
+
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.CreateWaitingRequest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventResponse;
 import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingEventService;
 import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingService;
 import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/dto/WaitingEventResponse.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/dto/WaitingEventResponse.java
@@ -1,0 +1,7 @@
+package online.partyrun.partyrunmatchingservice.domain.waiting.dto;
+
+public record WaitingEventResponse(String status) {
+    public WaitingEventResponse(WaitingStatus status) {
+        this(status.name());
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
@@ -3,8 +3,8 @@ package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
 import lombok.extern.slf4j.Slf4j;
+
 import online.partyrun.partyrunmatchingservice.domain.matching.controller.MatchingRequest;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventResponse;
@@ -18,8 +18,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-@Slf4j
 
+@Slf4j
 @Service
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 @RequiredArgsConstructor
@@ -35,19 +35,19 @@ public class WaitingEventService {
 
     public Flux<WaitingEventResponse> getEventStream(Mono<String> member) {
         return member.flatMapMany(
-                id ->
-                        waitingSinkHandler
-                                .connect(id)
-                                .doOnNext(
-                                        status -> {
-                                            if (status.isCompleted()) {
-                                                waitingSinkHandler.complete(id);
-                                            }
-                                        })
-                                .doOnSubscribe(
-                                        s ->
-                                                waitingSinkHandler.sendEvent(
-                                                        id, WaitingStatus.CONNECTED)))
+                        id ->
+                                waitingSinkHandler
+                                        .connect(id)
+                                        .doOnNext(
+                                                status -> {
+                                                    if (status.isCompleted()) {
+                                                        waitingSinkHandler.complete(id);
+                                                    }
+                                                })
+                                        .doOnSubscribe(
+                                                s ->
+                                                        waitingSinkHandler.sendEvent(
+                                                                id, WaitingStatus.CONNECTED)))
                 .map(WaitingEventResponse::new);
     }
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
@@ -4,8 +4,10 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
+import lombok.extern.slf4j.Slf4j;
 import online.partyrun.partyrunmatchingservice.domain.matching.controller.MatchingRequest;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
+import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventResponse;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
 import online.partyrun.partyrunmatchingservice.domain.waiting.queue.WaitingQueue;
 
@@ -16,6 +18,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+@Slf4j
 
 @Service
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
@@ -30,7 +33,7 @@ public class WaitingEventService {
         waitingSinkHandler.create(id);
     }
 
-    public Flux<WaitingStatus> getEventStream(Mono<String> member) {
+    public Flux<WaitingEventResponse> getEventStream(Mono<String> member) {
         return member.flatMapMany(
                 id ->
                         waitingSinkHandler
@@ -44,7 +47,8 @@ public class WaitingEventService {
                                 .doOnSubscribe(
                                         s ->
                                                 waitingSinkHandler.sendEvent(
-                                                        id, WaitingStatus.CONNECTED)));
+                                                        id, WaitingStatus.CONNECTED)))
+                .map(WaitingEventResponse::new);
     }
 
     public void sendMatchEvent(List<String> members) {

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
@@ -1,17 +1,16 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventResponse;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("WaitingEventService")
 @SpringBootTest
@@ -31,7 +30,7 @@ class WaitingEventServiceTest {
             waitingSinkHandler.create(user1.block());
 
             StepVerifier.create(waitingEventService.getEventStream(user1))
-                    .expectNext(WaitingStatus.CONNECTED)
+                    .expectNext(new WaitingEventResponse(WaitingStatus.CONNECTED))
                     .thenCancel()
                     .verify();
         }
@@ -51,7 +50,7 @@ class WaitingEventServiceTest {
                     member ->
                             StepVerifier.create(
                                             waitingEventService.getEventStream(Mono.just(member)))
-                                    .expectNext(WaitingStatus.MATCHED, WaitingStatus.CONNECTED)
+                                    .expectNext(new WaitingEventResponse(WaitingStatus.MATCHED), new WaitingEventResponse(WaitingStatus.CONNECTED))
                                     .verifyComplete());
         }
     }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
@@ -1,16 +1,18 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventResponse;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("WaitingEventService")
 @SpringBootTest
@@ -50,7 +52,9 @@ class WaitingEventServiceTest {
                     member ->
                             StepVerifier.create(
                                             waitingEventService.getEventStream(Mono.just(member)))
-                                    .expectNext(new WaitingEventResponse(WaitingStatus.MATCHED), new WaitingEventResponse(WaitingStatus.CONNECTED))
+                                    .expectNext(
+                                            new WaitingEventResponse(WaitingStatus.MATCHED),
+                                            new WaitingEventResponse(WaitingStatus.CONNECTED))
                                     .verifyComplete());
         }
     }


### PR DESCRIPTION
## 변경 사항
waiting event format을 클라이언트 요구에 따라 변경했습니다.

ex) "CONNECTED" -> {"status" : "CONNECTED"}

