### PR TITLE
fix : event 구독 시 항상 connected 이벤트가 먼저 전송되도록 변경 

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
@@ -31,6 +31,7 @@ public class WaitingEventService {
 
     public void register(final String id) {
         waitingSinkHandler.create(id);
+        waitingSinkHandler.sendEvent(id, WaitingStatus.CONNECTED);
     }
 
     public Flux<WaitingEventResponse> getEventStream(Mono<String> member) {
@@ -43,11 +44,7 @@ public class WaitingEventService {
                                                     if (status.isCompleted()) {
                                                         waitingSinkHandler.complete(id);
                                                     }
-                                                })
-                                        .doOnSubscribe(
-                                                s ->
-                                                        waitingSinkHandler.sendEvent(
-                                                                id, WaitingStatus.CONNECTED)))
+                                                }))
                 .map(WaitingEventResponse::new);
     }
 

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
@@ -1,16 +1,18 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventResponse;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("WaitingEventService")
 @SpringBootTest
@@ -20,7 +22,6 @@ class WaitingEventServiceTest {
     @Autowired WaitingSinkHandler waitingSinkHandler;
 
     Mono<String> user1 = Mono.just("현준");
-
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -37,7 +38,8 @@ class WaitingEventServiceTest {
                             StepVerifier.create(
                                             waitingEventService.getEventStream(Mono.just(member)))
                                     .expectNext(
-                                            new WaitingEventResponse(WaitingStatus.CONNECTED),  new WaitingEventResponse(WaitingStatus.MATCHED))
+                                            new WaitingEventResponse(WaitingStatus.CONNECTED),
+                                            new WaitingEventResponse(WaitingStatus.MATCHED))
                                     .verifyComplete());
         }
     }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
@@ -1,18 +1,16 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventResponse;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("WaitingEventService")
 @SpringBootTest
@@ -23,20 +21,6 @@ class WaitingEventServiceTest {
 
     Mono<String> user1 = Mono.just("현준");
 
-    @Nested
-    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-    class Waiting에_대한_이벤트_구독_시 {
-        @Test
-        @DisplayName("Connection 이벤트를발행한다")
-        void publishConnection() {
-            waitingSinkHandler.create(user1.block());
-
-            StepVerifier.create(waitingEventService.getEventStream(user1))
-                    .expectNext(new WaitingEventResponse(WaitingStatus.CONNECTED))
-                    .thenCancel()
-                    .verify();
-        }
-    }
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -53,8 +37,7 @@ class WaitingEventServiceTest {
                             StepVerifier.create(
                                             waitingEventService.getEventStream(Mono.just(member)))
                                     .expectNext(
-                                            new WaitingEventResponse(WaitingStatus.MATCHED),
-                                            new WaitingEventResponse(WaitingStatus.CONNECTED))
+                                            new WaitingEventResponse(WaitingStatus.CONNECTED),  new WaitingEventResponse(WaitingStatus.MATCHED))
                                     .verifyComplete());
         }
     }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingProcessTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingProcessTest.java
@@ -35,12 +35,13 @@ class WaitingProcessTest {
         waitingService.create(성우, request).block();
 
         StepVerifier.create(sseHandler.connect(현준.block()))
-                .expectNext(WaitingStatus.MATCHED)
+                .expectNext(WaitingStatus.CONNECTED, WaitingStatus.MATCHED)
                 .thenCancel()
                 .verify();
 
         StepVerifier.create((sseHandler.connect(성우.block())))
-                .expectNext(WaitingStatus.MATCHED)
+                .expectNext(WaitingStatus.CONNECTED, WaitingStatus.MATCHED)
+
                 .thenCancel()
                 .verify();
     }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingProcessTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingProcessTest.java
@@ -41,7 +41,6 @@ class WaitingProcessTest {
 
         StepVerifier.create((sseHandler.connect(성우.block())))
                 .expectNext(WaitingStatus.CONNECTED, WaitingStatus.MATCHED)
-
                 .thenCancel()
                 .verify();
     }


### PR DESCRIPTION
## 변경 사항

클라이언트의 요구사항에 따라, connection 시도 시에 connect 이벤트를 발행하지 않고, event 구독 시 항상 connected 이벤트가 먼저 전송되도록 변경하였습니다.  

## 알아야할 사항

## 테스트 방식
