### PR TITLE
refactor : matching status 삭제 및 matching confirm 부분 스레드 분할

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingController.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingController.java
@@ -31,7 +31,7 @@ public class MatchingController {
             Mono<Authentication> auth, @RequestBody MatchingRequest request) {
         return matchingService
                 .setMemberStatus(auth.map(Principal::getName), request)
-                .flatMap(i -> Mono.just(new MessageResponse("참여여부 등록")));
+                .then(Mono.defer(() -> Mono.just(new MessageResponse("참여여부 등록"))));
     }
 
     @GetMapping(path = "event", produces = MediaType.TEXT_EVENT_STREAM_VALUE)

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/entity/Matching.java
@@ -23,7 +23,6 @@ public class Matching {
     @Id String id;
     List<MatchingMember> members;
     int distance;
-    MatchingStatus status = MatchingStatus.WAIT;
     LocalDateTime startAt;
 
     public Matching(final List<MatchingMember> members, int distance, LocalDateTime startAt) {
@@ -47,19 +46,10 @@ public class Matching {
     }
 
     public void cancel() {
-        status = MatchingStatus.CANCEL;
         members.forEach(member -> member.changeStatus(MatchingMemberStatus.CANCELED));
     }
 
-    public void updateStatus() {
-        this.status = generateMatchingStatus();
-    }
-
-    public boolean isWait() {
-        return this.status.isWait();
-    }
-
-    private MatchingStatus generateMatchingStatus() {
+    public MatchingStatus getStatus() {
         if (this.members.stream().anyMatch(MatchingMember::isCanceled)) {
             return MatchingStatus.CANCEL;
         }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -2,12 +2,9 @@ package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
-import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
-
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.data.mongodb.repository.Update;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -24,5 +21,5 @@ public interface MatchingRepository extends ReactiveMongoRepository<Matching, St
     Mono<Void> updateMatchingMemberStatus(
             String matchingId, String memberId, MatchingMemberStatus status);
 
-    Flux<Matching> findAllByStatus(MatchingStatus status);
+    Flux<Matching> findAllByMembersStatus(MatchingMemberStatus status);
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -2,9 +2,11 @@ package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
+
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.data.mongodb.repository.Update;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
@@ -1,28 +1,26 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
 import online.partyrun.partyrunmatchingservice.global.controller.HttpControllerAdvice;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @ContextConfiguration(classes = {MatchingController.class, HttpControllerAdvice.class})
 @DisplayName("MatchingController")
@@ -39,7 +37,7 @@ class MatchingControllerTest extends WebfluxDocsTest {
     @DisplayName("post : match 수락 여부 전송")
     void postMatching() {
         given(matchingService.setMemberStatus(any(Mono.class), any(MatchingRequest.class)))
-                .willReturn(Mono.just(matching));
+                .willReturn(Mono.empty());
 
         client.post()
                 .uri("/matching")

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
@@ -1,26 +1,28 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
 import online.partyrun.partyrunmatchingservice.global.controller.HttpControllerAdvice;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @ContextConfiguration(classes = {MatchingController.class, HttpControllerAdvice.class})
 @DisplayName("MatchingController")

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
@@ -1,28 +1,27 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-
 import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @DataMongoTest
 @DisplayName("MatchingRepository")
 class MatchingRepositoryTest {
-    @Autowired MatchingRepository matchRepository;
+    @Autowired
+    MatchingRepository matchRepository;
     LocalDateTime now = LocalDateTime.now();
     List<MatchingMember> members =
             Stream.of("user1", "user2", "user3").map(MatchingMember::new).toList();
@@ -74,5 +73,30 @@ class MatchingRepositoryTest {
         assertThat(getMembers.get(0).getStatus()).isEqualTo(MatchingMemberStatus.READY);
         assertThat(getMembers.get(1).getStatus()).isEqualTo(MatchingMemberStatus.NO_RESPONSE);
         assertThat(getMembers.get(2).getStatus()).isEqualTo(MatchingMemberStatus.NO_RESPONSE);
+    }
+
+    @Test
+    @DisplayName("noResponse인 member가 있는 Matching을 탐색한다")
+    void runFindByNoResponse() {
+        Matching matching1 = matchRepository.save(new Matching(members, 1000, now)).block();
+        Matching matching2 = matchRepository.save(new Matching(members, 1000, now)).block();
+        Matching matching3 = matchRepository.save(new Matching(members, 1000, now)).block();
+        Matching matching4 = matchRepository.save(new Matching(members, 1000, now)).block();
+
+        matching1.getMembers().forEach(member -> matchRepository
+                .updateMatchingMemberStatus(
+                        matching1.getId(), member.getId(), MatchingMemberStatus.READY)
+                .block());
+
+        matching2.getMembers().forEach(member -> matchRepository
+                .updateMatchingMemberStatus(
+                        matching2.getId(), member.getId(), MatchingMemberStatus.CANCELED)
+                .block());
+
+        matchRepository.updateMatchingMemberStatus(matching3.getId(), members.get(0).getId(), MatchingMemberStatus.READY).block();
+
+        StepVerifier.create(matchRepository.findAllByMembersStatus(MatchingMemberStatus.NO_RESPONSE).map(Matching::getId))
+                .expectNext(matching3.getId(), matching4.getId())
+                .verifyComplete();
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
@@ -1,27 +1,28 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+
 import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @DataMongoTest
 @DisplayName("MatchingRepository")
 class MatchingRepositoryTest {
-    @Autowired
-    MatchingRepository matchRepository;
+    @Autowired MatchingRepository matchRepository;
     LocalDateTime now = LocalDateTime.now();
     List<MatchingMember> members =
             Stream.of("user1", "user2", "user3").map(MatchingMember::new).toList();
@@ -83,19 +84,37 @@ class MatchingRepositoryTest {
         Matching matching3 = matchRepository.save(new Matching(members, 1000, now)).block();
         Matching matching4 = matchRepository.save(new Matching(members, 1000, now)).block();
 
-        matching1.getMembers().forEach(member -> matchRepository
+        matching1
+                .getMembers()
+                .forEach(
+                        member ->
+                                matchRepository
+                                        .updateMatchingMemberStatus(
+                                                matching1.getId(),
+                                                member.getId(),
+                                                MatchingMemberStatus.READY)
+                                        .block());
+
+        matching2
+                .getMembers()
+                .forEach(
+                        member ->
+                                matchRepository
+                                        .updateMatchingMemberStatus(
+                                                matching2.getId(),
+                                                member.getId(),
+                                                MatchingMemberStatus.CANCELED)
+                                        .block());
+
+        matchRepository
                 .updateMatchingMemberStatus(
-                        matching1.getId(), member.getId(), MatchingMemberStatus.READY)
-                .block());
+                        matching3.getId(), members.get(0).getId(), MatchingMemberStatus.READY)
+                .block();
 
-        matching2.getMembers().forEach(member -> matchRepository
-                .updateMatchingMemberStatus(
-                        matching2.getId(), member.getId(), MatchingMemberStatus.CANCELED)
-                .block());
-
-        matchRepository.updateMatchingMemberStatus(matching3.getId(), members.get(0).getId(), MatchingMemberStatus.READY).block();
-
-        StepVerifier.create(matchRepository.findAllByMembersStatus(MatchingMemberStatus.NO_RESPONSE).map(Matching::getId))
+        StepVerifier.create(
+                        matchRepository
+                                .findAllByMembersStatus(MatchingMemberStatus.NO_RESPONSE)
+                                .map(Matching::getId))
                 .expectNext(matching3.getId(), matching4.getId())
                 .verifyComplete();
     }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
@@ -1,24 +1,19 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import lombok.SneakyThrows;
-
 import online.partyrun.partyrunmatchingservice.config.redis.RedisTestConfig;
 import online.partyrun.partyrunmatchingservice.domain.matching.controller.MatchingRequest;
+import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.repository.MatchingRepository;
-import online.partyrun.partyrunmatchingservice.domain.waiting.root.RunningDistance;
-
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
@@ -27,33 +22,30 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @SpringBootTest
 @DisplayName("MatchingService")
 @Import(RedisTestConfig.class)
 class MatchingServiceTest {
-    @Autowired MatchingService matchingService;
+    @Autowired
+    MatchingService matchingService;
     @Autowired MatchingSinkHandler sseHandler;
-    @Autowired MatchingRepository matchingRepository;
-    @Autowired Clock clock;
-
-    final List<String> members = List.of("현준", "성우", "준혁");
-    Mono<String> 현준 = Mono.just(members.get(0));
-    Mono<String> 성우 = Mono.just(members.get(1));
-    Mono<String> 준혁 = Mono.just(members.get(2));
+    @Autowired
+    MatchingRepository matchingRepository;
+    @Autowired
+    Clock clock;
+    String 현준 = "현준";
+    String 성우 = "성우";
+    String 준혁 = "준혁";
+    final List<String> members = List.of(현준, 성우, 준혁);
     MatchingRequest 수락 = new MatchingRequest(true);
     MatchingRequest 거절 = new MatchingRequest(false);
     final int distance = 1000;
 
-    @BeforeEach
-    void cleanup() {
-        sseHandler.shutdown();
-        matchingRepository.deleteAll().block();
-    }
-
     @Test
     @DisplayName("matching을 생성한다")
     void runCreate() {
-
         StepVerifier.create(matchingService.create(members, distance))
                 .assertNext(
                         matching -> {
@@ -64,7 +56,6 @@ class MatchingServiceTest {
                         })
                 .verifyComplete();
     }
-
     @Test
     @DisplayName("match 생성 시 sink connect를 생성한다")
     void runCreateSink() {
@@ -87,163 +78,93 @@ class MatchingServiceTest {
     }
 
     @Nested
-    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-    class Member생성을_진행한_후_Member_상태_변경_요청시 {
+    @DisplayNameGeneration(ReplaceUnderscores.class)
+    class member_모두가_승인시 {
+        Matching matching;
+        @BeforeEach
+        void setup() {
+            matching = matchingService.create(members, distance).block();
+            matchingService.setMemberStatus(Mono.just(현준), 수락).block();
+            matchingService.setMemberStatus(Mono.just(성우), 수락).block();
+            matchingService.setMemberStatus(Mono.just(준혁), 수락).block();
+        }
 
         @Test
-        @DisplayName("member 상태를 설정한다")
-        void runSetMemberStatus() {
-            matchingService.create(members, distance).block();
-
-            StepVerifier.create(matchingService.setMemberStatus(현준, 수락))
-                    .assertNext(
-                            match -> {
-                                assertThat(match.getMembers().stream().map(MatchingMember::getId))
-                                        .contains("현준", "성우", "준혁");
-                                assertThat(match.getDistance()).isEqualTo(distance);
-                                assertThat(match.getStatus()).isEqualTo(MatchingStatus.WAIT);
-                            })
+        @DisplayName("매치 상태가 success 로 반환한다")
+        void changeSuccess() {
+            StepVerifier.create(matchingRepository.findById(matching.getId()))
+                    .assertNext(m -> assertThat(m.getStatus()).isEqualTo(MatchingStatus.SUCCESS))
                     .verifyComplete();
         }
 
-        @Nested
-        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-        class member가_거절할_경우 {
-            @Test
-            @DisplayName("매치 상태를 캔슬로 변경한다")
-            void runSetMemberStatus() {
-                matchingService.create(members, distance).block();
-
-                StepVerifier.create(matchingService.setMemberStatus(현준, 거절))
-                        .assertNext(
-                                match -> {
-                                    assertThat(
-                                                    match.getMembers().stream()
-                                                            .map(MatchingMember::getId))
-                                            .contains("현준", "성우", "준혁");
-                                    assertThat(match.getDistance())
-                                            .isEqualTo(RunningDistance.M1000.getMeter());
-                                    assertThat(match.getStatus()).isEqualTo(MatchingStatus.CANCEL);
-                                })
-                        .verifyComplete();
-            }
-
-            @Test
-            @DisplayName("이전에 사람들이 수락을 했어도 캔슬로 변경한다")
-            void runCancel() {
-                matchingService.create(members, distance).block();
-                matchingService.setMemberStatus(성우, 수락).block();
-                matchingService.setMemberStatus(준혁, 수락).block();
-
-                StepVerifier.create(matchingService.setMemberStatus(현준, 거절))
-                        .assertNext(
-                                match -> {
-                                    assertThat(
-                                                    match.getMembers().stream()
-                                                            .map(MatchingMember::getId))
-                                            .contains("현준", "성우", "준혁");
-                                    assertThat(match.getDistance())
-                                            .isEqualTo(RunningDistance.M1000.getMeter());
-                                    assertThat(match.getStatus()).isEqualTo(MatchingStatus.CANCEL);
-                                })
-                        .verifyComplete();
-            }
-
-            @Test
-            @DisplayName("내가 수락을 했어도 다른사람이 거절하면 캔슬로 변경한다")
-            void runCancelIf() {
-                matchingService.create(members, distance).block();
-                matchingService.setMemberStatus(성우, 수락).block();
-                matchingService.setMemberStatus(준혁, 거절).block();
-
-                StepVerifier.create(matchingService.setMemberStatus(현준, 수락))
-                        .assertNext(
-                                match -> {
-                                    assertThat(
-                                                    match.getMembers().stream()
-                                                            .map(MatchingMember::getId))
-                                            .contains("현준", "성우", "준혁");
-                                    assertThat(match.getDistance())
-                                            .isEqualTo(RunningDistance.M1000.getMeter());
-                                    assertThat(match.getStatus()).isEqualTo(MatchingStatus.CANCEL);
-                                })
-                        .verifyComplete();
-            }
-
-            @Test
-            @DisplayName("동시 요청시에도 수행한다.")
-            void runParallel() {
-                final Matching matcing = matchingService.create(members, distance).block();
-
-                final Mono<Matching> publisher1 = matchingService.setMemberStatus(현준, 수락);
-                final Mono<Matching> publisher2 = matchingService.setMemberStatus(성우, 수락);
-                final Mono<Matching> publisher3 = matchingService.setMemberStatus(준혁, 수락);
-                Flux.zip(publisher1, publisher2, publisher3)
-                        .subscribeOn(Schedulers.parallel())
-                        .blockLast();
-
-                final Matching block = matchingRepository.findById(matcing.getId()).block();
-                assertThat(block.getStatus()).isEqualTo(MatchingStatus.SUCCESS);
-            }
-
-            @Test
-            @DisplayName("구독을 진행시에 거절 이벤트를 받고 종료한다.")
-            void runSubscribe() {
-                matchingService.create(members, 1000).block();
-                matchingService.setMemberStatus(현준, 거절).block();
-
-                StepVerifier.create(matchingService.getEventSteam(현준))
-                        .expectNextCount(2)
-                        .verifyComplete();
-                assertThat(sseHandler.getConnectors()).isNotIn(현준.block());
-            }
+        @Test
+        @DisplayName("구독 진행 시 수락 이벤트를 받고 종료된다")
+        void completeSubscribe() {
+            final MatchEvent result = matchingService.getEventSteam(Mono.just(현준)).blockLast();
+            assertThat(result.status()).isEqualTo(MatchingStatus.SUCCESS);
         }
 
-        @Nested
-        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-        class member모두가_수락한_경우 {
-            @Test
-            @DisplayName("member 상태를 설정한 후에 매치 상태도 성공으로 변경한다")
-            void runSetMemberStatus() {
-                matchingService.create(members, distance).block();
-                matchingService.setMemberStatus(성우, 수락).block();
-                matchingService.setMemberStatus(준혁, 수락).block();
-                StepVerifier.create(matchingService.setMemberStatus(현준, 수락))
-                        .assertNext(
-                                match -> {
-                                    assertThat(
-                                                    match.getMembers().stream()
-                                                            .map(MatchingMember::getId))
-                                            .contains("현준", "성우", "준혁");
-                                    assertThat(match.getDistance())
-                                            .isEqualTo(RunningDistance.M1000.getMeter());
-                                    assertThat(match.getStatus()).isEqualTo(MatchingStatus.SUCCESS);
-                                })
-                        .verifyComplete();
-            }
+        @Test
+        @DisplayName("배틀 생성을 요청한다")
+        void createBattle() {
+            // TODO
+        }
 
-            @Test
-            @DisplayName("구독을 진행시에 수락 이벤트를 받고 종료한다.")
-            void runSubscribe() {
-                matchingService.create(members, 1000).block();
-                int eventCount = 1 + members.size(); // Connection 값, 각 member 수락 이벤트 값 포함
-                members.forEach(
-                        member -> matchingService.setMemberStatus(Mono.just(member), 수락).block());
 
-                members.forEach(
-                        member ->
-                                StepVerifier.create(
-                                                matchingService.getEventSteam(Mono.just(member)))
-                                        .expectNextCount(eventCount)
-                                        .verifyComplete());
-                assertThat(sseHandler.getConnectors()).isEmpty();
-            }
+    }
+
+    @Nested
+    @DisplayNameGeneration(ReplaceUnderscores.class)
+    class 한_명이라도_거절_시 {
+        Matching matching;
+        @BeforeEach
+        void setup() {
+            matching = matchingService.create(members, distance).block();
+            matchingService.setMemberStatus(Mono.just(현준), 수락).block();
+            matchingService.setMemberStatus(Mono.just(성우), 수락).block();
+            matchingService.setMemberStatus(Mono.just(준혁), 거절).block();
+        }
+
+        @Test
+        @DisplayName("매치 상태가 cancel 로 반환한다")
+        void changeSuccess() {
+            StepVerifier.create(matchingRepository.findById(matching.getId()))
+                    .assertNext(m -> assertThat(m.getStatus()).isEqualTo(MatchingStatus.CANCEL))
+                    .verifyComplete();
+        }
+
+        @Test
+        @DisplayName("구독 진행 시 cancel 이벤트를 받고 종료된다")
+        void completeSubscribe() {
+            final MatchEvent result = matchingService.getEventSteam(Mono.just(현준)).blockLast();
+            assertThat(result.status()).isEqualTo(MatchingStatus.CANCEL);
+        }
+
+    }
+
+    @Nested
+    @DisplayNameGeneration(ReplaceUnderscores.class)
+    class 동시에_요청시 {
+        @Test
+        @DisplayName("동시에 전원 요청을 수락해도 상태가 success 로 반환한다")
+        void trySuccess() {
+            final Matching matching = matchingService.create(members, distance).block();
+            Mono.zip(matchingService.setMemberStatus(Mono.just(현준), 수락),
+                    matchingService.setMemberStatus(Mono.just(성우), 수락),
+                    matchingService.setMemberStatus(Mono.just(준혁), 수락))
+                    .subscribeOn(Schedulers.parallel())
+                    .block();
+
+
+            StepVerifier.create(matchingRepository.findById(matching.getId()))
+                    .assertNext(m -> assertThat(m.getStatus()).isEqualTo(MatchingStatus.SUCCESS))
+                    .verifyComplete();
         }
     }
 
     @Nested
-    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-    class Scadule이_동작할때 {
+    @DisplayNameGeneration(ReplaceUnderscores.class)
+    class 스케줄러가_동작할_때 {
         Clock mockClock = Clock.fixed(clock.instant().plusSeconds(14400), clock.getZone());
 
         MatchingService laterMatchingService =
@@ -260,11 +181,12 @@ class MatchingServiceTest {
                                 laterMatchingService.removeUnConnectedSink();
                                 return Mono.delay(Duration.ofMillis(20));
                             })
+                    .publishOn(Schedulers.boundedElastic())
                     .doOnTerminate(
                             () -> {
                                 final Matching matching =
                                         matchingRepository
-                                                .findAllByStatus(MatchingStatus.WAIT)
+                                                .findAllByMembersStatus(MatchingMemberStatus.NO_RESPONSE)
                                                 .blockLast();
                                 assertThat(sseHandler.getConnectors()).isEmpty();
                                 assertThat(matching).isNull();
@@ -279,7 +201,7 @@ class MatchingServiceTest {
             matchingService.create(members, 1000).block();
             matchingService.removeUnConnectedSink();
 
-            StepVerifier.create(matchingRepository.findAllByStatus(MatchingStatus.WAIT))
+            StepVerifier.create(matchingRepository.findAllByMembersStatus(MatchingMemberStatus.NO_RESPONSE))
                     .expectNextCount(1)
                     .verifyComplete();
             assertThat(sseHandler.getConnectors()).isNotEmpty();


### PR DESCRIPTION
## 변경 사항
matching status 필드를 굳이 가지고 있을 필요가 없어 제거를 하였고, matching member의 status에 따라 matching status를 얻을 수 있도록 설계했습니다.
 또한 matching confirm 및 multicast 하는 로직을 publishOn을 통해 별도 스레드에서 동작하게 설정하였습니다.
## 사유
 matching confirm 로직을 별도 스레드에서 동작하는 이유는 향후 battle 생성 로직이 blocking하게 동작하여 블로킹 로직을 별도 스레드에서 진행하게 할 수 있도록 다음과 같이 설정했습니다. 기존 동작로직과 향후 동작 로직에 관한 다이어그램을 아래 첨부합니다.
![image](https://github.com/SWM-KAWAI-MANS/party-run-matching-service/assets/55674648/5ee7b2cc-b341-4ff3-9d1b-539b280bc677)
![image](https://github.com/SWM-KAWAI-MANS/party-run-matching-service/assets/55674648/0a051f4d-ecc2-4a86-b47e-28f063e82e5b)

## 알아야할 사항
향후 confirm matching 부분에 battle 생성 요청 로직을 추가할 계획입니다.
webflux 스케줄러 및 publishOn 관련 설명 https://why-doing.tistory.com/135