### PR TITLE
refactor : 매칭 참여 여부 API 엔드포인트 변경

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingController.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingController.java
@@ -26,7 +26,7 @@ import java.security.Principal;
 public class MatchingController {
     MatchingService matchingService;
 
-    @PostMapping
+    @PostMapping("members/join")
     @ResponseStatus(HttpStatus.CREATED)
     public Mono<MessageResponse> postMatchStatus(
             Mono<Authentication> auth, @RequestBody MatchingRequest request) {

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
@@ -1,5 +1,9 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchingResponse;
@@ -7,21 +11,19 @@ import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
 import online.partyrun.partyrunmatchingservice.global.controller.HttpControllerAdvice;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @ContextConfiguration(classes = {MatchingController.class, HttpControllerAdvice.class})
 @DisplayName("MatchingController")

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/controller/MatchingControllerTest.java
@@ -1,9 +1,5 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchEvent;
 import online.partyrun.partyrunmatchingservice.domain.matching.dto.MatchingResponse;
@@ -11,19 +7,21 @@ import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingService;
 import online.partyrun.partyrunmatchingservice.global.controller.HttpControllerAdvice;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @ContextConfiguration(classes = {MatchingController.class, HttpControllerAdvice.class})
 @DisplayName("MatchingController")
@@ -43,7 +41,7 @@ class MatchingControllerTest extends WebfluxDocsTest {
                 .willReturn(Mono.empty());
 
         client.post()
-                .uri("/matching")
+                .uri("/matching/members/join")
                 .bodyValue(new MatchingRequest(true))
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()


### PR DESCRIPTION
## 변경 사항
기존 경로가 Restful하지 않아서 URL을 /matching 에서 /matching/members/join 으로 변경했습니다
