### PR TITLE
fix : matching 상태 update 로직 싱글 스레드에서 동작하도록 변경

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -75,7 +75,7 @@ public class MatchingService {
                                                                 memberId,
                                                                 MatchingMemberStatus.getByIsJoin(
                                                                         request.isJoin()))
-                                                        .publishOn(Schedulers.boundedElastic())
+                                                        .publishOn(Schedulers.single())
                                                         .then(
                                                                 Mono.fromRunnable(
                                                                         () ->
@@ -86,7 +86,6 @@ public class MatchingService {
     private void confirmMatching(String matchingId) {
         matchingRepository
                 .findById(matchingId)
-                .publishOn(Schedulers.boundedElastic())
                 .flatMap(
                         matching -> {
                             if (matching.getStatus().equals(MatchingStatus.SUCCESS)) {

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
@@ -1,6 +1,11 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
 import lombok.SneakyThrows;
+
 import online.partyrun.partyrunmatchingservice.config.redis.RedisTestConfig;
 import online.partyrun.partyrunmatchingservice.domain.battle.service.BattleService;
 import online.partyrun.partyrunmatchingservice.domain.matching.controller.MatchingRequest;
@@ -11,12 +16,14 @@ import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMe
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.repository.MatchingRepository;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -27,10 +34,6 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 
 @SpringBootTest
 @DisplayName("MatchingService")
@@ -240,14 +243,14 @@ class MatchingServiceTest {
             given(battleService.create(any(List.class), any(Integer.class)))
                     .willReturn(Mono.just("battleId"));
 
-            final Flux<Tuple3<Void, Void, Void>> plan = Flux.zip(
-                            matchingService.setMemberStatus(Mono.just(현준), 수락),
-                            matchingService.setMemberStatus(Mono.just(성우), 수락),
-                            matchingService.setMemberStatus(Mono.just(준혁), 수락))
-                    .subscribeOn(Schedulers.parallel());
+            final Flux<Tuple3<Void, Void, Void>> plan =
+                    Flux.zip(
+                                    matchingService.setMemberStatus(Mono.just(현준), 수락),
+                                    matchingService.setMemberStatus(Mono.just(성우), 수락),
+                                    matchingService.setMemberStatus(Mono.just(준혁), 수락))
+                            .subscribeOn(Schedulers.parallel());
 
-            StepVerifier.create(plan)
-                    .verifyComplete();
+            StepVerifier.create(plan).verifyComplete();
         }
     }
 }


### PR DESCRIPTION
## 변경 사항
기존에 member의 수락/거절 여부를 병렬처리를 통해 업데이트를 진행하여 동시성 문제가 발생했습니다. 
해당 문제를 해결하기 위해 member 수락/거절 업데이트 후 matching 상태에 따른 배틀 생성 요청 및 이벤트 멀티 캐스팅을 싱글 스레드에서 동작하도록 변경하였습니다. 
## 알아야할 사항
synchronized, redis 분산락, 트랜젝션 등 다양한 방법을 시도했으나, 결국 멀티 스레드 환경에서는 제약이 많았습니다. 
