### PR TITLE
fix : 최근 매칭 탐색 repository 로직 변경

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -17,6 +17,7 @@ public interface MatchingRepository extends ReactiveMongoRepository<Matching, St
             List<String> memberIds, MatchingMemberStatus memberStatus);
 
     Mono<Matching> findByMembersIdAndMembersStatus(String id, MatchingMemberStatus status);
+
     Mono<Matching> findFirstByMembersIdOrderByStartAtDesc(String id);
 
     @Query("{'id': ?0, 'members.id': ?1}")

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepository.java
@@ -17,6 +17,7 @@ public interface MatchingRepository extends ReactiveMongoRepository<Matching, St
             List<String> memberIds, MatchingMemberStatus memberStatus);
 
     Mono<Matching> findByMembersIdAndMembersStatus(String id, MatchingMemberStatus status);
+    Mono<Matching> findFirstByMembersIdOrderByStartAtDesc(String id);
 
     @Query("{'id': ?0, 'members.id': ?1}")
     @Update("{$set : {'members.$.status': ?2}}")

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingService.java
@@ -144,10 +144,7 @@ public class MatchingService {
     }
 
     public Mono<MatchingMembersResponse> getResent(Mono<String> auth) {
-        return auth.flatMap(
-                        memberId ->
-                                matchingRepository.findByMembersIdAndMembersStatus(
-                                        memberId, MatchingMemberStatus.NO_RESPONSE))
+        return auth.flatMap(matchingRepository::findFirstByMembersIdOrderByStartAtDesc)
                 .map(MatchingMembersResponse::new);
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
@@ -1,23 +1,21 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-
 import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataMongoTest
 @DisplayName("MatchingRepository")
@@ -117,5 +115,17 @@ class MatchingRepositoryTest {
                                 .map(Matching::getId))
                 .expectNext(matching3.getId(), matching4.getId())
                 .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("가장 최근에 등록한 matching을 탐색한다")
+    void findResent() {
+        Matching matching1 = matchRepository.save(new Matching(members, 1000, now.minusHours(1))).block();
+        Matching matching2 = matchRepository.save(new Matching(members, 1000, now.minusHours(2))).block();
+        Matching expect = matchRepository.save(new Matching(members, 1000, now)).block();
+        Matching matching4 = matchRepository.save(new Matching(members, 1000, now.minusHours(3))).block();
+
+        final Matching target = matchRepository.findFirstByMembersIdOrderByStartAtDesc(members.get(0).getId()).block();
+        assertThat(target.getId()).isEqualTo(expect.getId());
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/repository/MatchingRepositoryTest.java
@@ -1,21 +1,23 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.Matching;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMember;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingMemberStatus;
 import online.partyrun.partyrunmatchingservice.domain.matching.entity.MatchingStatus;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+
 import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DataMongoTest
 @DisplayName("MatchingRepository")
@@ -120,12 +122,18 @@ class MatchingRepositoryTest {
     @Test
     @DisplayName("가장 최근에 등록한 matching을 탐색한다")
     void findResent() {
-        Matching matching1 = matchRepository.save(new Matching(members, 1000, now.minusHours(1))).block();
-        Matching matching2 = matchRepository.save(new Matching(members, 1000, now.minusHours(2))).block();
+        Matching matching1 =
+                matchRepository.save(new Matching(members, 1000, now.minusHours(1))).block();
+        Matching matching2 =
+                matchRepository.save(new Matching(members, 1000, now.minusHours(2))).block();
         Matching expect = matchRepository.save(new Matching(members, 1000, now)).block();
-        Matching matching4 = matchRepository.save(new Matching(members, 1000, now.minusHours(3))).block();
+        Matching matching4 =
+                matchRepository.save(new Matching(members, 1000, now.minusHours(3))).block();
 
-        final Matching target = matchRepository.findFirstByMembersIdOrderByStartAtDesc(members.get(0).getId()).block();
+        final Matching target =
+                matchRepository
+                        .findFirstByMembersIdOrderByStartAtDesc(members.get(0).getId())
+                        .block();
         assertThat(target.getId()).isEqualTo(expect.getId());
     }
 }


### PR DESCRIPTION
## 변경 사항
최근 매칭 탐색에 대한 repository 로직을 변경했습니다.
기존에는 member id가 포함되는 매칭에서 member가 무응답한 매칭만 전송을 하였습니다. 그러다보니, 이미 ready 여부를 보낸 이후에는 매칭을 조회할 수 없었습니다.

따라서 요구 그대로 필터 없이 최근 매칭에 대한 정보를 전송하도록 변경하였습니다.
