### PR TITLE
feat : waiting event 취소 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -36,3 +36,8 @@ operation::get-matching-event[snippets='http-request,http-response']
 operation::get-matching-by-id[snippets='http-request,http-response']
 
 
+=== waiting event 취소
+operation::cancel-waiting-event[snippets='http-request,http-response']
+
+
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -35,6 +35,8 @@ operation::get-matching-event[snippets='http-request,http-response']
 
 operation::get-matching-by-id[snippets='http-request,http-response']
 
+=== shutdown
+operation::shutdown[snippets='http-request,http-response']
 
 === waiting event 취소
 operation::cancel-waiting-event[snippets='http-request,http-response']

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingController.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingController.java
@@ -47,4 +47,10 @@ public class WaitingController {
     public void deleteWaiting() {
         waitingEventService.shutdown();
     }
+
+    @PostMapping("event/cancel")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<MessageResponse> cancelEvent(Mono<Authentication> auth) {
+        return waitingEventService.cancel(auth.map(Principal::getName));
+    }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
@@ -11,6 +11,7 @@ import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventRe
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
 import online.partyrun.partyrunmatchingservice.domain.waiting.queue.WaitingQueue;
 
+import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -68,5 +69,12 @@ public class WaitingEventService {
     public void shutdown() {
         waitingSinkHandler.shutdown();
         waitingQueue.clear();
+    }
+
+    public Mono<MessageResponse> cancel(final Mono<String> member) {
+        return member.doOnNext(memberId -> {
+            waitingSinkHandler.disconnectIfExist(memberId);
+            waitingQueue.delete(memberId);
+        }).then(Mono.just(new MessageResponse("cancelled")));
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
@@ -10,8 +10,8 @@ import online.partyrun.partyrunmatchingservice.domain.matching.service.MatchingS
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventResponse;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
 import online.partyrun.partyrunmatchingservice.domain.waiting.queue.WaitingQueue;
-
 import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -72,9 +72,11 @@ public class WaitingEventService {
     }
 
     public Mono<MessageResponse> cancel(final Mono<String> member) {
-        return member.doOnNext(memberId -> {
-            waitingSinkHandler.disconnectIfExist(memberId);
-            waitingQueue.delete(memberId);
-        }).then(Mono.just(new MessageResponse("cancelled")));
+        return member.doOnNext(
+                        memberId -> {
+                            waitingSinkHandler.disconnectIfExist(memberId);
+                            waitingQueue.delete(memberId);
+                        })
+                .then(Mono.just(new MessageResponse("cancelled")));
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
@@ -1,9 +1,5 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.CreateWaitingRequest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
@@ -12,16 +8,18 @@ import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingEve
 import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingService;
 import online.partyrun.partyrunmatchingservice.global.controller.HttpControllerAdvice;
 import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @ContextConfiguration(classes = {WaitingController.class, HttpControllerAdvice.class})
 @WithMockUser
@@ -96,5 +94,20 @@ class WaitingControllerTest extends WebfluxDocsTest {
                 .isNoContent()
                 .expectBody()
                 .consumeWith(document("delete waiting"));
+    }
+
+    @Test
+    @DisplayName("event cancel을 수행한다")
+    void cancelEvent() {
+        given(waitingEventService.cancel(any(Mono.class)))
+                .willReturn(Mono.just(new MessageResponse("cancelled")));
+
+        client.post()
+                .uri("/waiting/event/cancel")
+                .exchange()
+                .expectStatus()
+                .isNoContent()
+                .expectBody()
+                .consumeWith(document("cancel-waiting-event"));
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
@@ -1,5 +1,9 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.CreateWaitingRequest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
@@ -8,18 +12,16 @@ import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingEve
 import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingService;
 import online.partyrun.partyrunmatchingservice.global.controller.HttpControllerAdvice;
 import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @ContextConfiguration(classes = {WaitingController.class, HttpControllerAdvice.class})
 @WithMockUser

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
@@ -93,7 +93,7 @@ class WaitingControllerTest extends WebfluxDocsTest {
                 .expectStatus()
                 .isNoContent()
                 .expectBody()
-                .consumeWith(document("delete waiting"));
+                .consumeWith(document("shutdown"));
     }
 
     @Test

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
@@ -1,23 +1,21 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunmatchingservice.config.redis.RedisTestConfig;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.CreateWaitingRequest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventResponse;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
 import online.partyrun.partyrunmatchingservice.domain.waiting.queue.WaitingQueue;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("WaitingEventService")
 @SpringBootTest
@@ -77,6 +75,17 @@ class WaitingEventServiceTest {
         waitingService.create(user1, new CreateWaitingRequest(1000)).block();
 
         waitingEventService.getEventStream(user1).subscribe().dispose();
+        assertAll(
+                () -> assertThat(waitingQueue.hasMember(user1.block())).isFalse(),
+                () -> assertThat(waitingSinkHandler.getConnectors()).isNotIn(user1.block()));
+    }
+
+    @Test
+    @DisplayName("취소 요청을 보내면 sink를 삭제하고, 대기queue에도 삭제한다")
+    void requestCancel() {
+        waitingService.create(user1, new CreateWaitingRequest(1000)).block();
+
+        waitingEventService.cancel(user1).block();
         assertAll(
                 () -> assertThat(waitingQueue.hasMember(user1.block())).isFalse(),
                 () -> assertThat(waitingSinkHandler.getConnectors()).isNotIn(user1.block()));

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
@@ -1,21 +1,23 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import online.partyrun.partyrunmatchingservice.config.redis.RedisTestConfig;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.CreateWaitingRequest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventResponse;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
 import online.partyrun.partyrunmatchingservice.domain.waiting.queue.WaitingQueue;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("WaitingEventService")
 @SpringBootTest


### PR DESCRIPTION
## 변경 사항
기존에 구현한 cancel을 통해서는 클라이언트 측에서 강제로 disconnect 해도 동작하지 않는 것을 확인했습니다. 로컬에서도 doFinally 등으로도 체이닝 했을 때도 disconnect를 체킹할 방법이 없어서 결국 cancel 로직을 API로 별도로 개발했습니다.
