### PR TITLE
feat : 전역 Debug log 설정 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,7 @@ jacocoTestCoverageVerification {
                     '**.WebfluxAuthFilter*',
                     '**.*Event*',
                     '**.external.**',
-                    '**.Advisor.**'
+                    '**.*Advisor*'
             ]
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ bootJar {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -178,7 +179,8 @@ jacocoTestCoverageVerification {
                     '**.*ControllerAdvice*',
                     '**.WebfluxAuthFilter*',
                     '**.*Event*',
-                    '**.external.**'
+                    '**.external.**',
+                    '**.Advisor.**'
             ]
         }
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingSinkHandler.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingSinkHandler.java
@@ -3,21 +3,12 @@ package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
-import online.partyrun.partyrunmatchingservice.domain.waiting.queue.WaitingQueue;
 import online.partyrun.partyrunmatchingservice.global.sse.SinkHandlerTemplate;
-
 import org.springframework.stereotype.Component;
 
 @Component
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 @RequiredArgsConstructor
 public class WaitingSinkHandler extends SinkHandlerTemplate<String, WaitingStatus> {
-    WaitingQueue waitingQueue;
-
-    @Override
-    protected Runnable onCancel(String key) {
-        return () -> waitingQueue.delete(key);
-    }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingSinkHandler.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingSinkHandler.java
@@ -3,12 +3,13 @@ package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
 import online.partyrun.partyrunmatchingservice.global.sse.SinkHandlerTemplate;
+
 import org.springframework.stereotype.Component;
 
 @Component
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 @RequiredArgsConstructor
-public class WaitingSinkHandler extends SinkHandlerTemplate<String, WaitingStatus> {
-}
+public class WaitingSinkHandler extends SinkHandlerTemplate<String, WaitingStatus> {}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/advisor/LogAdvisor.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/advisor/LogAdvisor.java
@@ -1,6 +1,7 @@
 package online.partyrun.partyrunmatchingservice.global.advisor;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
@@ -12,17 +13,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class LogAdvisor {
 
-    //partyrunservice 속한 모든 패키지의 모든 클래스의 모든 메서드
+    // partyrunservice 속한 모든 패키지의 모든 클래스의 모든 메서드
     @Pointcut("execution(* online.partyrun.partyrunmatchingservice..*.*(..))")
-    public void allComponents(){}
-
+    public void allComponents() {}
 
     @Before("allComponents()")
-    public void generateTraceLong(JoinPoint joinPoint)  {
+    public void generateTraceLong(JoinPoint joinPoint) {
         log.debug(
                 "METHOD : {}, ARGS : {}",
                 joinPoint.getSignature().toShortString(),
                 joinPoint.getArgs());
-
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/advisor/LogAdvisor.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/advisor/LogAdvisor.java
@@ -1,0 +1,28 @@
+package online.partyrun.partyrunmatchingservice.global.advisor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Slf4j
+@Component
+public class LogAdvisor {
+
+    //partyrunservice 속한 모든 패키지의 모든 클래스의 모든 메서드
+    @Pointcut("execution(* online.partyrun.partyrunmatchingservice..*.*(..))")
+    public void allComponents(){}
+
+
+    @Before("allComponents()")
+    public void generateTraceLong(JoinPoint joinPoint)  {
+        log.debug(
+                "METHOD : {}, ARGS : {}",
+                joinPoint.getSignature().toShortString(),
+                joinPoint.getArgs());
+
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/advisor/LogAdvisor.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/advisor/LogAdvisor.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 public class LogAdvisor {
 
     // partyrunservice 속한 모든 패키지의 모든 클래스의 모든 메서드
-    @Pointcut("execution(* online.partyrun.partyrunmatchingservice..*.*(..))")
+    @Pointcut("within(online.partyrun.partyrunmatchingservice..*)")
     public void allComponents() {}
 
     @Before("allComponents()")

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/advisor/LogAdvisor.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/advisor/LogAdvisor.java
@@ -1,6 +1,7 @@
 package online.partyrun.partyrunmatchingservice.global.advisor;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
@@ -18,7 +19,8 @@ public class LogAdvisor {
 
     @Before("allComponents()")
     public void generateTraceLong(JoinPoint joinPoint) {
-        log.debug("{}.{}({})",
+        log.debug(
+                "{}.{}({})",
                 joinPoint.getSignature().getDeclaringType().getSimpleName(),
                 joinPoint.getSignature().getName(),
                 joinPoint.getArgs());

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/advisor/LogAdvisor.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/advisor/LogAdvisor.java
@@ -1,7 +1,6 @@
 package online.partyrun.partyrunmatchingservice.global.advisor;
 
 import lombok.extern.slf4j.Slf4j;
-
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
@@ -19,9 +18,9 @@ public class LogAdvisor {
 
     @Before("allComponents()")
     public void generateTraceLong(JoinPoint joinPoint) {
-        log.debug(
-                "METHOD : {}, ARGS : {}",
-                joinPoint.getSignature().toShortString(),
+        log.debug("{}.{}({})",
+                joinPoint.getSignature().getDeclaringType().getSimpleName(),
+                joinPoint.getSignature().getName(),
                 joinPoint.getArgs());
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/sse/SinkHandlerTemplate.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/sse/SinkHandlerTemplate.java
@@ -26,23 +26,12 @@ public abstract class SinkHandlerTemplate<K, V> implements ServerSentEventHandle
         return getSink(key)
                 .asFlux()
                 .timeout(timeout())
-                .doOnCancel(doOnCancel(key))
+                .doOnCancel(() -> sinks.remove(key))
                 .doOnError(
                         e -> {
                             sinks.remove(key);
                             throw new SseConnectionException();
                         });
-    }
-
-    private Runnable doOnCancel(K key) {
-        return () -> {
-            sinks.remove(key);
-            onCancel(key);
-        };
-    }
-
-    protected Runnable onCancel(K key) {
-        return () -> {};
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,9 @@ jwt:
 external:
   battle:
     url: "https://dev.partyrun.online"
+logging:
+  level:
+    root: debug
 ---
 
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,9 @@ jwt:
 external:
   battle:
     url: "https://dev.partyrun.online"
+logging:
+  level:
+    root: debug
 ---
 spring:
   config:
@@ -52,3 +55,6 @@ jwt:
 external:
   battle:
     url: ${BATTLE_SERVICE_URL}
+logging:
+  level:
+    root: debug

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -70,12 +70,32 @@
             <maxHistory>${MAX_HISTORY}</maxHistory>
         </rollingPolicy>
     </appender>
+    <appender name="DEBUG_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+        <file>${LOGS_ABSOLUTE_PATH}/debug.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>DEBUG</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <Pattern>${LOG_PATTERN}</Pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOGS_ABSOLUTE_PATH}/debug.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>100MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>${MAX_HISTORY}</maxHistory>
+        </rollingPolicy>
+    </appender>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="INFO_LOG"/>
         <appender-ref ref="WARN_LOG"/>
         <appender-ref ref="ERROR_LOG"/>
+        <appender-ref ref="DEBUG_LOG"/>
     </root>
 
 </configuration>

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
@@ -1,21 +1,23 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import online.partyrun.partyrunmatchingservice.config.redis.RedisTestConfig;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.CreateWaitingRequest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventResponse;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
 import online.partyrun.partyrunmatchingservice.domain.waiting.queue.WaitingQueue;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("WaitingEventService")
 @SpringBootTest
@@ -33,6 +35,7 @@ class WaitingEventServiceTest {
         waitingSinkHandler.shutdown();
         waitingQueue.clear();
     }
+
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 여러명이_등록되었을_때 {


### PR DESCRIPTION
## 변경 사항
기존에 로그를 이용해서 각 컴포넌트를 Trace하는데 어려움이 있어서 AOP를 통해 별도 log를 추적하는 컴포넌트를 구성하였습니다.
log level을 Trace가 아닌 Debug로 한 이유는 Trace시 불필요한 로그 내용이 많았기에 Debug 레벨로 진행하였습니다.

#### trace 내용들 예
```
[2023-08-17 13:47:10:372][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Ignored because not matching any filter: file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/exception/InternalServerException.class]
[2023-08-17 13:47:10:372][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Scanning file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/exception/InvalidSinksKeyException.class]
[2023-08-17 13:47:10:373][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Ignored because not matching any filter: file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/exception/InvalidSinksKeyException.class]
[2023-08-17 13:47:10:373][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Scanning file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/exception/SseConnectionException.class]
[2023-08-17 13:47:10:373][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Ignored because not matching any filter: file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/exception/SseConnectionException.class]
[2023-08-17 13:47:10:373][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Scanning file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/mongo/MongoConfig.class]
[2023-08-17 13:47:10:374][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Scanning file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/security/AuthUser.class]
[2023-08-17 13:47:10:374][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Ignored because not matching any filter: file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/security/AuthUser.class]
[2023-08-17 13:47:10:374][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Scanning file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/security/AuthorizationException.class]
[2023-08-17 13:47:10:374][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Ignored because not matching any filter: file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/security/AuthorizationException.class]
[2023-08-17 13:47:10:374][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Scanning file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/security/WebfluxAuthFilter.class]
[2023-08-17 13:47:10:374][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Scanning file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/security/WebfluxSecurityConfig.class]
[2023-08-17 13:47:10:375][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Scanning file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/sse/ServerSentEventHandler.class]
[2023-08-17 13:47:10:375][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Ignored because not matching any filter: file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/sse/ServerSentEventHandler.class]
[2023-08-17 13:47:10:375][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Scanning file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/sse/SinkHandlerTemplate.class]
[2023-08-17 13:47:10:375][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Ignored because not matching any filter: file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/sse/SinkHandlerTemplate.class]
[2023-08-17 13:47:10:375][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Scanning file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/sse/exception/KeyNotExistException.class]
[2023-08-17 13:47:10:376][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Ignored because not matching any filter: file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/sse/exception/KeyNotExistException.class]
[2023-08-17 13:47:10:376][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Scanning file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/sse/exception/NullKeyException.class]
[2023-08-17 13:47:10:376][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Ignored because not matching any filter: file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/sse/exception/NullKeyException.class]
[2023-08-17 13:47:10:376][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Scanning file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/sse/exception/SseConnectionException.class]
[2023-08-17 13:47:10:376][main] TRACE o.s.c.a.ClassPathBeanDefinitionScanner - Ignored because not matching any filter: file [/Users/parkhyeonjun/dev/swm/kms/party-run-matching-service/out/production/classes/online/partyrun/partyrunmatchingservice/global/sse/exception/SseConnectionException.class]
[2023-08-17 13:47:10:395][main] TRACE o.s.c.i.s.SpringFactoriesLoader - Loaded [org.springframework.boot.autoconfigure.AutoConfigurationImportFilter] names: [org.springframework.boot.autoconfigure.condition.OnBeanCondition, org.springframework.boot.autoconfigure.condition.OnClassCondition, org.springframework.boot.autoconfigure.condition.OnWebApplicationCondition]
[2023-08-17 13:47:10:402][main] TRACE o.s.b.f.s.DefaultListableBeanFactory - Returning cached instance of singleton bean 'autoConfigurationReport'
```

advisor를 통해 로그를 다음과 같이 생성합니다 
```
[2023-08-17 14:25:20:10248][parallel-5] DEBUG o.p.p.global.advisor.LogAdvisor - METHOD : WaitingEventService.register(..), ARGS : [qwer]
[2023-08-17 14:25:20:10248][parallel-5] DEBUG o.p.p.global.advisor.LogAdvisor - METHOD : SinkHandlerTemplate.create(..), ARGS : [qwer]
[2023-08-17 14:25:20:10248][parallel-5] DEBUG o.p.p.global.advisor.LogAdvisor - METHOD : SinkHandlerTemplate.sendEvent(..), ARGS : [qwer, CONNECTED]
[2023-08-17 14:25:20:10248][parallel-5] DEBUG o.p.p.global.advisor.LogAdvisor - METHOD : WaitingMessagePublisher.publish(..), ARGS : [WaitingMember[memberId=qwer, distance=M1000]]
```

---

추가적으로 대기 Cancel  로직에서 불필요한 부분 삭제했습니다. 처음에는 문제 없었는데, 이후 Cancel 로직이 개선된 이후에 fail이 뜨네요