### PR TITLE
refactor : waiting cancel 시 status 변경

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingController.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingController.java
@@ -45,7 +45,7 @@ public class WaitingController {
     }
 
     @PostMapping("event/cancel")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ResponseStatus(HttpStatus.OK)
     public Mono<MessageResponse> cancelEvent(Mono<Authentication> auth) {
         return waitingEventService.cancel(auth.map(Principal::getName));
     }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/controller/WaitingControllerTest.java
@@ -1,9 +1,5 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
-
 import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.CreateWaitingRequest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
@@ -12,16 +8,18 @@ import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingEve
 import online.partyrun.partyrunmatchingservice.domain.waiting.service.WaitingService;
 import online.partyrun.partyrunmatchingservice.global.controller.HttpControllerAdvice;
 import online.partyrun.partyrunmatchingservice.global.dto.MessageResponse;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @ContextConfiguration(classes = {WaitingController.class, HttpControllerAdvice.class})
 @WithMockUser
@@ -108,7 +106,7 @@ class WaitingControllerTest extends WebfluxDocsTest {
                 .uri("/waiting/event/cancel")
                 .exchange()
                 .expectStatus()
-                .isNoContent()
+                .isOk()
                 .expectBody()
                 .consumeWith(document("cancel-waiting-event"));
     }


### PR DESCRIPTION
## 변경 사항
 waiting event cancel 시에 Http Response status를 204 no content 에서 200 ok로 변경했습니다.
클라이언트 측에서 body가 없으면 error로 간주하는 문제가 발생하였는데, 204 상태일때는 body에 어떠한 값을 넣어도 들어가지 않는 것을 확인하여 200으로 상태를 변경하였습니다.
