### PR TITLE
feat : waiting cancel시 Event 추가

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/dto/WaitingStatus.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/dto/WaitingStatus.java
@@ -2,9 +2,10 @@ package online.partyrun.partyrunmatchingservice.domain.waiting.dto;
 
 public enum WaitingStatus {
     CONNECTED,
-    MATCHED;
+    MATCHED,
+    CANCEL;
 
     public boolean isCompleted() {
-        return this.equals(MATCHED);
+        return !this.equals(CONNECTED);
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventService.java
@@ -78,7 +78,7 @@ public class WaitingEventService {
     }
 
     private void checkDisconnectAndDeleteWaiting(final String memberId) {
-        waitingSinkHandler.disconnectIfExist(memberId);
+        waitingSinkHandler.sendEvent(memberId, WaitingStatus.CANCEL);
         waitingQueue.delete(memberId);
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
@@ -1,23 +1,21 @@
 package online.partyrun.partyrunmatchingservice.domain.waiting.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunmatchingservice.config.redis.RedisTestConfig;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.CreateWaitingRequest;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingEventResponse;
 import online.partyrun.partyrunmatchingservice.domain.waiting.dto.WaitingStatus;
 import online.partyrun.partyrunmatchingservice.domain.waiting.queue.WaitingQueue;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("WaitingEventService")
 @SpringBootTest
@@ -83,8 +81,10 @@ class WaitingEventServiceTest {
         waitingService.create(user1, new CreateWaitingRequest(1000)).block();
 
         waitingEventService.cancel(user1).block();
+        final WaitingEventResponse response = waitingEventService.getEventStream(user1).blockLast();
         assertAll(
                 () -> assertThat(waitingQueue.hasMember(user1.block())).isFalse(),
+                () -> assertThat(response.status()).isEqualTo(WaitingStatus.CANCEL.toString()),
                 () -> assertThat(waitingSinkHandler.getConnectors()).isNotIn(user1.block()));
     }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/waiting/service/WaitingEventServiceTest.java
@@ -32,6 +32,7 @@ class WaitingEventServiceTest {
     void before() {
         waitingSinkHandler.shutdown();
         waitingQueue.clear();
+        waitingQueue.delete(user1.block());
     }
 
     @Nested


### PR DESCRIPTION
## 변경 사항
waiting cancel 시 cancel이라는 Event를 추가하여 전달하도록 구현하였습니다.
기존에는 별도 event 없이 complete를 하였는데, 그러다보니 클라이언트 측에서 EOF error가 터지는 문제가 발생했습니다. 
이러한 문제를 해결하기 위해 cancel시에도 event를 전송한 후 complete하도록 변경하였습니다.