### PR TITLE
feat : 같이하기(party) 관련 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -41,5 +41,14 @@ operation::shutdown[snippets='http-request,http-response']
 === waiting event 취소
 operation::cancel-waiting-event[snippets='http-request,http-response']
 
+== Party
 
+=== party 생성
+operation::create-party[snippets='http-request,http-response']
+=== party 참여
+operation::join-party[snippets='http-request,http-response']
+=== party running 시작
+operation::start-party[snippets='http-request,http-response']
+=== party 나가기
+operation::quit-party[snippets='http-request,http-response']
 

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/controller/PartyController.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/controller/PartyController.java
@@ -1,0 +1,47 @@
+package online.partyrun.partyrunmatchingservice.domain.party.controller;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunmatchingservice.domain.party.dto.PartyEvent;
+import online.partyrun.partyrunmatchingservice.domain.party.dto.PartyIdResponse;
+import online.partyrun.partyrunmatchingservice.domain.party.dto.PartyRequest;
+import online.partyrun.partyrunmatchingservice.domain.party.service.PartyService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@RequestMapping("parties")
+public class PartyController {
+    PartyService partyService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<PartyIdResponse> postParties(Mono<Authentication> auth, @RequestBody PartyRequest request) {
+        return partyService.create(auth.map(Principal::getName), request);
+    }
+
+    @GetMapping(path = "{entryCode}/join", produces = "text/event-stream")
+    public Flux<PartyEvent> getPartyEventStream(Mono<Authentication> auth, @PathVariable String entryCode) {
+        return partyService.getEventStream(auth.map(Principal::getName), entryCode);
+    }
+
+    @PostMapping("{entryCode}/start")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<Void> postPartyStart(Mono<Authentication> auth, @PathVariable String entryCode) {
+        return partyService.start(auth.map(Principal::getName), entryCode);
+    }
+
+    @PostMapping("{entryCode}/quit")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<Void> postPartyQuit(Mono<Authentication> auth, @PathVariable String entryCode) {
+        return partyService.quit(auth.map(Principal::getName), entryCode);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/controller/PartyController.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/controller/PartyController.java
@@ -30,7 +30,7 @@ public class PartyController {
 
     @GetMapping(path = "{entryCode}/join", produces = "text/event-stream")
     public Flux<PartyEvent> getPartyEventStream(Mono<Authentication> auth, @PathVariable String entryCode) {
-        return partyService.getEventStream(auth.map(Principal::getName), entryCode);
+        return partyService.joinAndConnectSink(auth.map(Principal::getName), entryCode);
     }
 
     @PostMapping("{entryCode}/start")

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/dto/PartyEvent.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/dto/PartyEvent.java
@@ -1,0 +1,12 @@
+package online.partyrun.partyrunmatchingservice.domain.party.dto;
+
+import online.partyrun.partyrunmatchingservice.domain.party.entity.Party;
+import online.partyrun.partyrunmatchingservice.domain.party.entity.PartyStatus;
+
+import java.util.List;
+
+public record PartyEvent(String entryCode, String leaderId, PartyStatus status, List<String> participants, String battleId) {
+    public PartyEvent(Party party) {
+        this(party.getEntryCode().getCode(), party.getLeaderId(), party.getStatus(), party.getParticipants(), party.getBattleId());
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/dto/PartyIdResponse.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/dto/PartyIdResponse.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunmatchingservice.domain.party.dto;
+
+import online.partyrun.partyrunmatchingservice.domain.party.entity.Party;
+
+public record PartyIdResponse(String code) {
+    public PartyIdResponse(Party party) {
+        this(party.getEntryCode().getCode());
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/dto/PartyRequest.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/dto/PartyRequest.java
@@ -1,0 +1,4 @@
+package online.partyrun.partyrunmatchingservice.domain.party.dto;
+
+public record PartyRequest(int distance) {
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/EntryCode.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/EntryCode.java
@@ -1,0 +1,26 @@
+package online.partyrun.partyrunmatchingservice.domain.party.entity;
+
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class EntryCode {
+    private static int MIN_RANDOM_NUMBER = 100_000;
+    private static int MAX_RANDOM_NUMBER = 999_999;
+
+    private String code;
+
+    public EntryCode() {
+        this.code = generateRandomRoomId();
+    }
+
+    private String generateRandomRoomId() {
+        return String.valueOf(ThreadLocalRandom.current().nextInt(MIN_RANDOM_NUMBER, MAX_RANDOM_NUMBER + 1));
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/EntryCode.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/EntryCode.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import java.util.concurrent.ThreadLocalRandom;
+import java.security.SecureRandom;
 
 @Getter
 @AllArgsConstructor
@@ -21,6 +21,6 @@ public class EntryCode {
     }
 
     private String generateRandomRoomId() {
-        return String.valueOf(ThreadLocalRandom.current().nextInt(MIN_RANDOM_NUMBER, MAX_RANDOM_NUMBER + 1));
+        return String.valueOf(new SecureRandom().nextInt(MIN_RANDOM_NUMBER, MAX_RANDOM_NUMBER + 1));
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/Party.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/Party.java
@@ -1,0 +1,41 @@
+package online.partyrun.partyrunmatchingservice.domain.party.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunmatchingservice.domain.waiting.root.RunningDistance;
+import org.springframework.data.annotation.Id;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Party {
+    @Id
+    String id;
+    EntryCode entryCode = new EntryCode();
+    String leaderId;
+    RunningDistance distance;
+
+    PartyStatus status = PartyStatus.WAITING;
+    List<String> participants = new ArrayList<>();
+    String battleId;
+
+    public Party(String leaderId, RunningDistance distance) {
+        this.leaderId = leaderId;
+        this.distance = distance;
+    }
+
+    public void join(String memberId) {
+        participants.add(memberId);
+    }
+
+
+    public void start(String battleId) {
+        this.battleId = battleId;
+        status = PartyStatus.COMPLETED;
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/PartyStatus.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/PartyStatus.java
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunmatchingservice.domain.party.entity;
+
+public enum PartyStatus {
+    WAITING, COMPLETED
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/repository/PartyRepository.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/repository/PartyRepository.java
@@ -1,0 +1,11 @@
+package online.partyrun.partyrunmatchingservice.domain.party.repository;
+
+import online.partyrun.partyrunmatchingservice.domain.party.entity.EntryCode;
+import online.partyrun.partyrunmatchingservice.domain.party.entity.Party;
+import online.partyrun.partyrunmatchingservice.domain.party.entity.PartyStatus;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import reactor.core.publisher.Mono;
+
+public interface PartyRepository extends ReactiveMongoRepository<Party, String> {
+    Mono<Party> findByEntryCodeAndStatus(EntryCode code, PartyStatus status);
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/service/PartyService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/service/PartyService.java
@@ -31,7 +31,7 @@ public class PartyService {
                 .map(PartyIdResponse::new);
     }
 
-    public Flux<PartyEvent> getEventStream(Mono<String> member, String entryCode) {
+    public Flux<PartyEvent> joinAndConnectSink(Mono<String> member, String entryCode) {
         return member
                 .doOnNext(partySinkHandler::create)
                 .flatMap(memberId -> joinParty(memberId, entryCode))

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/service/PartyService.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/service/PartyService.java
@@ -1,0 +1,81 @@
+package online.partyrun.partyrunmatchingservice.domain.party.service;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunmatchingservice.domain.battle.service.BattleService;
+import online.partyrun.partyrunmatchingservice.domain.party.dto.PartyEvent;
+import online.partyrun.partyrunmatchingservice.domain.party.dto.PartyIdResponse;
+import online.partyrun.partyrunmatchingservice.domain.party.dto.PartyRequest;
+import online.partyrun.partyrunmatchingservice.domain.party.entity.EntryCode;
+import online.partyrun.partyrunmatchingservice.domain.party.entity.Party;
+import online.partyrun.partyrunmatchingservice.domain.party.entity.PartyStatus;
+import online.partyrun.partyrunmatchingservice.domain.party.repository.PartyRepository;
+import online.partyrun.partyrunmatchingservice.domain.waiting.root.RunningDistance;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@RequiredArgsConstructor
+public class PartyService {
+    PartyRepository partyRepository;
+    PartySinkHandler partySinkHandler;
+    BattleService battleService;
+
+    public Mono<PartyIdResponse> create(Mono<String> member, PartyRequest request) {
+        return member.map(memberId ->
+                        new Party(memberId, RunningDistance.getBy(request.distance())))
+                .flatMap(partyRepository::save)
+                .map(PartyIdResponse::new);
+    }
+
+    public Flux<PartyEvent> getEventStream(Mono<String> member, String entryCode) {
+        return member
+                .doOnNext(partySinkHandler::create)
+                .flatMap(memberId -> joinParty(memberId, entryCode))
+                .then(member)
+                .flatMapMany(partySinkHandler::connect);
+    }
+
+    private Mono<Void> joinParty(String memberId, String entryCode) {
+        return getWaitingParty(entryCode)
+                .flatMap(party -> {
+                            party.join(memberId);
+                            return partyRepository.save(party);
+                        }
+                )
+                .then(multicast(entryCode));
+    }
+
+    private Mono<Void> multicast(String code) {
+        return getWaitingParty(code)
+                .doOnNext(party -> party.getParticipants().forEach(
+                        member -> partySinkHandler.sendEvent(member, new PartyEvent(party))
+                )).then();
+    }
+
+    private Mono<Party> getWaitingParty(String code) {
+        return partyRepository.findByEntryCodeAndStatus(new EntryCode(code), PartyStatus.WAITING);
+    }
+
+    public Mono<Void> start(Mono<String> member, String code) {
+        // TODO 방장 여부 확인
+        return getWaitingParty(code).flatMap(party ->
+                        battleService.create(party.getParticipants(), party.getDistance().getMeter())
+                ).flatMap(battleId ->
+                        getWaitingParty(code).doOnNext(party -> party.start(battleId))
+                                .flatMap(partyRepository::save))
+                .doOnNext(party -> party.getParticipants().forEach(
+                        partyMember -> {
+                            partySinkHandler.sendEvent(partyMember, new PartyEvent(party));
+                            partySinkHandler.complete(partyMember);
+                        }
+                )).then();
+    }
+    public Mono<Void> quit(Mono<String> member, String code) {
+        // TODO
+        throw new UnsupportedOperationException("Not supported yet");
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/service/PartySinkHandler.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/service/PartySinkHandler.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunmatchingservice.domain.party.service;
+
+import online.partyrun.partyrunmatchingservice.domain.party.dto.PartyEvent;
+import online.partyrun.partyrunmatchingservice.global.sse.SinkHandlerTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PartySinkHandler extends SinkHandlerTemplate<String, PartyEvent> {
+}

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
@@ -1,6 +1,5 @@
 package online.partyrun.partyrunmatchingservice.domain.matching.service;
 
-import lombok.SneakyThrows;
 import online.partyrun.partyrunmatchingservice.config.redis.RedisTestConfig;
 import online.partyrun.partyrunmatchingservice.domain.battle.service.BattleService;
 import online.partyrun.partyrunmatchingservice.domain.matching.controller.MatchingRequest;
@@ -179,7 +178,6 @@ class MatchingServiceTest {
 
         @Test
         @DisplayName("TIMEOUT된 Match를 삭제한다")
-        @SneakyThrows
         void runDeleteIfTimeOver() {
             matchingService.create(members, 1000).block();
 

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/party/controller/PartyControllerTest.java
@@ -1,0 +1,103 @@
+package online.partyrun.partyrunmatchingservice.domain.party.controller;
+
+import online.partyrun.partyrunmatchingservice.config.docs.WebfluxDocsTest;
+import online.partyrun.partyrunmatchingservice.domain.party.dto.PartyEvent;
+import online.partyrun.partyrunmatchingservice.domain.party.dto.PartyIdResponse;
+import online.partyrun.partyrunmatchingservice.domain.party.dto.PartyRequest;
+import online.partyrun.partyrunmatchingservice.domain.party.entity.PartyStatus;
+import online.partyrun.partyrunmatchingservice.domain.party.service.PartyService;
+import online.partyrun.partyrunmatchingservice.global.controller.HttpControllerAdvice;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
+
+@ContextConfiguration(classes = {PartyController.class, HttpControllerAdvice.class})
+@DisplayName("PartyController")
+@WithMockUser
+class PartyControllerTest extends WebfluxDocsTest {
+    @MockBean
+    PartyService partyService;
+
+    private static final String ENTRY_CODE = "123456";
+
+    @Test
+    @DisplayName("post : party 생성")
+    void postParties() {
+        PartyRequest request = new PartyRequest(1000);
+        given(partyService.create(any(Mono.class), any(PartyRequest.class)))
+                .willReturn(Mono.just(new PartyIdResponse("123456")));
+
+        client.post()
+                .uri("/parties")
+                .bodyValue(request)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isCreated()
+                .expectBody()
+                .consumeWith(document("create-party"));
+    }
+
+    @Test
+    @DisplayName("get : join party")
+    void getPartyEventStream() {
+        final Flux<PartyEvent> eventResult = Flux.just(
+                new PartyEvent(ENTRY_CODE, "member1", PartyStatus.WAITING, List.of("member1"), null),
+                new PartyEvent(ENTRY_CODE, "member1", PartyStatus.WAITING, List.of("member1", "member2"), null),
+                new PartyEvent(ENTRY_CODE, "member1", PartyStatus.COMPLETED, List.of("member1", "member2"), "battle-id")
+        );
+        given(partyService.joinAndConnectSink(any(Mono.class), any(String.class)))
+                .willReturn(eventResult);
+
+        client.get()
+                .uri("/parties/{entryCode}/join", ENTRY_CODE)
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .consumeWith(document("join-party"));
+    }
+
+    @Test
+    @DisplayName("post : start party")
+    void partyStart() {
+        given(partyService.start(any(Mono.class), any(String.class)))
+                .willReturn(Mono.empty());
+
+        client.post()
+                .uri("/parties/{entryCode}/start",ENTRY_CODE)
+                .exchange()
+                .expectStatus()
+                .isNoContent()
+                .expectBody()
+                .consumeWith(document("start-party"));
+    }
+
+    @Test
+    @DisplayName("post : quit party")
+    void quitParty() {
+        given(partyService.start(any(Mono.class), any(String.class)))
+                .willReturn(Mono.empty());
+
+        client.post()
+                .uri("/parties/{entryCode}/quit",ENTRY_CODE)
+                .exchange()
+                .expectStatus()
+                .isNoContent()
+                .expectBody()
+                .consumeWith(document("quit-party"));
+    }
+
+}

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/party/entity/EntryCodeTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/party/entity/EntryCodeTest.java
@@ -1,0 +1,17 @@
+package online.partyrun.partyrunmatchingservice.domain.party.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EntryCodeTest {
+    @Test
+    @DisplayName("entryCode 생성 시 100,000 - 999,999 중 랜덤한 값으로 생성한다.")
+    void constructRandom() {
+        EntryCode code = new EntryCode();
+        Integer value = Integer.parseInt(code.getCode());
+
+        assertThat(value).isBetween(100_000, 999_999);
+    }
+}

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/party/entity/PartyTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/party/entity/PartyTest.java
@@ -1,0 +1,34 @@
+package online.partyrun.partyrunmatchingservice.domain.party.entity;
+
+import online.partyrun.partyrunmatchingservice.domain.waiting.root.RunningDistance;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("party에서")
+class PartyTest {
+    @Test
+    @DisplayName("join을 하면 참여자 명단에 추가를 한다.")
+    void join() {
+        Party party = new Party("leader", RunningDistance.M1000);
+        String newMember = "newMember";
+        party.join(newMember);
+
+        assertThat(party.getParticipants()).contains(newMember);
+    }
+
+    @Test
+    @DisplayName("시작을 하면 주어진 battle ID로 설정을 하고, COMPLETED로 상태로 변경한다.")
+    void start() {
+        Party party = new Party("leader", RunningDistance.M1000);
+        String battleId = "battleId";
+        party.start(battleId);
+
+        assertAll(
+                () -> assertThat(party.getBattleId()).isEqualTo(battleId),
+                () -> assertThat(party.getStatus()).isEqualTo(PartyStatus.COMPLETED)
+        );
+    }
+}

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/party/service/PartyServiceTest.java
@@ -1,0 +1,99 @@
+package online.partyrun.partyrunmatchingservice.domain.party.service;
+
+import online.partyrun.partyrunmatchingservice.config.redis.RedisTestConfig;
+import online.partyrun.partyrunmatchingservice.domain.battle.service.BattleService;
+import online.partyrun.partyrunmatchingservice.domain.party.dto.PartyEvent;
+import online.partyrun.partyrunmatchingservice.domain.party.entity.EntryCode;
+import online.partyrun.partyrunmatchingservice.domain.party.entity.Party;
+import online.partyrun.partyrunmatchingservice.domain.party.entity.PartyStatus;
+import online.partyrun.partyrunmatchingservice.domain.party.repository.PartyRepository;
+import online.partyrun.partyrunmatchingservice.domain.waiting.root.RunningDistance;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@DisplayName("partyService")
+@Import(RedisTestConfig.class)
+class PartyServiceTest {
+    @Autowired
+    PartyService partyService;
+    @Autowired
+    PartyRepository partyRepository;
+    @Autowired
+    PartySinkHandler partySinkHandler;
+    @MockBean
+    BattleService battleService;
+
+
+    Mono<String> 현준 = Mono.just("현준");
+    Mono<String> 성우 = Mono.just("성우");
+    Party partySample = new Party(현준.block(), RunningDistance.M1000);
+
+    @AfterEach
+    public void clear() {
+        partyRepository.deleteAll().block();
+    }
+
+    @Nested
+    @DisplayNameGeneration(ReplaceUnderscores.class)
+    class 파티가_생성된_후 {
+        EntryCode code = partyRepository.save(partySample).block().getEntryCode();
+        PartyEvent event = new PartyEvent(code.getCode(), 현준.block(), PartyStatus.WAITING, List.of(현준.block()), null);
+
+        @BeforeEach
+        void setUp() {
+            given(battleService.create(any(List.class), any(Integer.class)))
+                    .willReturn(Mono.just("battleId"));
+            code = partyRepository.save(partySample).block().getEntryCode();
+        }
+
+        @Test
+        @DisplayName("join 시에 party 명단에 추가하고, envet를 sink를 생성하여 참여자에게 전파한다.")
+        void joinParty() {
+
+            StepVerifier.create(partyService.joinAndConnectSink(현준, code.getCode()))
+                    .assertNext(res -> assertThat(res).isEqualTo(event))
+                    .thenCancel()
+                    .verify();
+        }
+
+        @Test
+        @DisplayName("게임 시작시에 이벤트를 전송하고, 완료 처리를 한다.")
+        void gameStart() {
+
+            partyService.joinAndConnectSink(현준, code.getCode()).blockFirst();
+            partySinkHandler.create(현준.block());
+            partyService.joinAndConnectSink(성우, code.getCode()).blockFirst();
+            partySinkHandler.create(성우.block());
+            partyService.start(현준, code.getCode()).block();
+
+            final Party partyResult = partyRepository.findByEntryCodeAndStatus(code, PartyStatus.COMPLETED).block();
+            assertAll(
+                    () -> assertThat(partySinkHandler.isExist(현준.block())).isFalse(),
+                    () -> assertThat(partySinkHandler.isExist(성우.block())).isFalse(),
+                    () -> assertThat(partyResult.getParticipants()).contains(현준.block(), 성우.block())
+            );
+        }
+
+        @Test
+        @DisplayName("미구현 : 파티 나가기를 수행한다.")
+        void quitParty() {
+            assertThatThrownBy(() -> partyService.quit(현준, "asdf"))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 개요
같이하기 기능(Party mode에 대한) 기능을 구현하였습니다
 3가지 기능을 구현하였습니다.
1.  Party 생성
- Party를 생성하고, 생성자가 방장이 됩니다.
- 참여 코드는 100,000 ~ 999,999 중 무작위 값으로 설정합니다.
- 중복을 대비하여 참여 코드와, Party Id는 별도로 설정했습니다. 
2. Party 참여
- 기존 Waiting, Matching과 달리, event를 구독하면 바로 sink를 생성한 후 구독하도록 설정하였습니다. 
- join시 party에 명단을 추가하고, sink event stream을 전달합니다.
- 다른 참여자들에게도 party에 대한 event를 multicast 합니다. 
3. Party 시작
- party 시작 시에 battle service에 create 요청을 보낸 후 id를 받아와 party에 저장합니다.
- Complete로 상태를 변경한 후, party 참여자들에게 이벤트를 전송하고, sink를 종료시킵니다.

## 향후 계획
1. PartyEntity에 대한 값 검증
- 현재 null check 및 별도 state에 대한 예외 설정을 해당 PR에 반영을 안했습니다. 다음 PR에 추가할 계획입니다.
6. 방장만 게임 시작 할 수 있도록 설정
7. quit 기능 구현