### PR TITLE
feat : party 나가기 기능 구현

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/Party.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/Party.java
@@ -38,4 +38,15 @@ public class Party {
         this.battleId = battleId;
         status = PartyStatus.COMPLETED;
     }
+
+    public void quit(final String memberId) {
+        participants.remove(memberId);
+        if(memberId.equals(managerId)) {
+            status = PartyStatus.CANCELLED;
+        }
+    }
+
+    public boolean isRecruitClosed() {
+        return !status.isWaiting();
+    }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/PartyStatus.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/PartyStatus.java
@@ -1,5 +1,9 @@
 package online.partyrun.partyrunmatchingservice.domain.party.entity;
 
 public enum PartyStatus {
-    WAITING, COMPLETED
+    WAITING, COMPLETED, CANCELLED;
+
+    public boolean isWaiting() {
+        return this.equals(WAITING);
+    }
 }

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/party/entity/PartyTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/party/entity/PartyTest.java
@@ -1,28 +1,30 @@
 package online.partyrun.partyrunmatchingservice.domain.party.entity;
 
 import online.partyrun.partyrunmatchingservice.domain.waiting.root.RunningDistance;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("party에서")
 class PartyTest {
+    final String manager = "방장";
+    final String member = "참여자";
+
     @Test
     @DisplayName("join을 하면 참여자 명단에 추가를 한다.")
     void join() {
-        Party party = new Party("leader", RunningDistance.M1000);
-        String newMember = "newMember";
-        party.join(newMember);
+        Party party = new Party(manager, RunningDistance.M1000);
+        party.join(member);
 
-        assertThat(party.getParticipants()).contains(newMember);
+        assertThat(party.getParticipants()).contains(member);
     }
 
     @Test
     @DisplayName("시작을 하면 주어진 battle ID로 설정을 하고, COMPLETED로 상태로 변경한다.")
     void start() {
-        Party party = new Party("leader", RunningDistance.M1000);
+        Party party = new Party(manager, RunningDistance.M1000);
         String battleId = "battleId";
         party.start(battleId);
 
@@ -30,5 +32,42 @@ class PartyTest {
                 () -> assertThat(party.getBattleId()).isEqualTo(battleId),
                 () -> assertThat(party.getStatus()).isEqualTo(PartyStatus.COMPLETED)
         );
+    }
+
+    @Nested
+    @DisplayNameGeneration(ReplaceUnderscores.class)
+    class 참가자가_나가면 {
+        Party party;
+
+        @BeforeEach
+        void beforeEach() {
+            party = new Party(manager, RunningDistance.M1000);
+            party.join(manager);
+            party.join(member);
+        }
+
+        @Test
+        @DisplayName("명단에서 제거한다")
+        void deleteParticipants() {
+            party.quit(member);
+
+            assertAll(
+                    () -> assertThat(party.getParticipants()).isNotIn(member),
+                    () -> assertThat(party.getParticipants()).contains(manager),
+                    () -> assertThat(party.getStatus()).isEqualTo(PartyStatus.WAITING)
+            );
+        }
+
+        @Test
+        @DisplayName("만약 방장이면 CANCELLED로 상태를 변경한다")
+        void changeCancelIfManager() {
+            party.quit(manager);
+
+            assertAll(
+                    () -> assertThat(party.getParticipants()).isNotIn(manager),
+                    () -> assertThat(party.getParticipants()).contains(member),
+                    () -> assertThat(party.getStatus()).isEqualTo(PartyStatus.CANCELLED)
+            );
+        }
     }
 }


### PR DESCRIPTION
## 개요
파티 나가기 기능을 구현하였습니다. 기존에 Controller을 미리 구축했어서 비즈니스 로직만 추가하면 됐습니다.
만약 방장인 경우 quit 시에 party 자체가 종료되도록 설정하였습니다.
또한, multicast 부분에 중복되는 부분이 있어 리펙터링을 병행하였습니다.