### PR TITLE
feat : Party Validation 로직 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -51,4 +51,5 @@ operation::join-party[snippets='http-request,http-response']
 operation::start-party[snippets='http-request,http-response']
 === party 나가기
 operation::quit-party[snippets='http-request,http-response']
-
+=== 탐색한 party가 없으면 예외
+operation::throw-exception-when-party-not-found[snippets='http-request,http-response']

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/dto/PartyEvent.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/dto/PartyEvent.java
@@ -3,16 +3,16 @@ package online.partyrun.partyrunmatchingservice.domain.party.dto;
 import online.partyrun.partyrunmatchingservice.domain.party.entity.Party;
 import online.partyrun.partyrunmatchingservice.domain.party.entity.PartyStatus;
 
-import java.util.List;
+import java.util.Set;
 
 public record PartyEvent(String entryCode,
                          int distance,
                          String managerId,
                          PartyStatus status,
-                         List<String> participants,
+                         Set<String> participantIds,
                          String battleId) {
     public PartyEvent(Party party) {
         this(party.getEntryCode().getCode(), party.getDistance().getMeter(), party.getManagerId(),
-                party.getStatus(), party.getParticipants(), party.getBattleId());
+                party.getStatus(), party.getParticipantIds(), party.getBattleId());
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/Party.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/entity/Party.java
@@ -4,16 +4,21 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunmatchingservice.domain.party.exception.IllegalArgumentIdException;
+import online.partyrun.partyrunmatchingservice.domain.party.exception.NotSatisfyMemberCountException;
+import online.partyrun.partyrunmatchingservice.domain.party.exception.PartyClosedException;
 import online.partyrun.partyrunmatchingservice.domain.waiting.root.RunningDistance;
 import org.springframework.data.annotation.Id;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Party {
+    private static final int MIN_PARTY_START_MEMBER_SIZE = 2;
     @Id
     String id;
     EntryCode entryCode = new EntryCode();
@@ -21,26 +26,39 @@ public class Party {
     RunningDistance distance;
 
     PartyStatus status = PartyStatus.WAITING;
-    List<String> participants = new ArrayList<>();
+    Set<String> participantIds = new HashSet<>();
     String battleId;
 
     public Party(String managerId, RunningDistance distance) {
+        validateArgumentId(managerId);
         this.managerId = managerId;
         this.distance = distance;
     }
 
     public void join(String memberId) {
-        participants.add(memberId);
+        validateArgumentId(memberId);
+        participantIds.add(memberId);
     }
 
 
     public void start(String battleId) {
+        validateArgumentId(battleId);
+        validatePartyState();
         this.battleId = battleId;
         status = PartyStatus.COMPLETED;
     }
+    private void validatePartyState() {
+        if(!status.isWaiting()) {
+            throw new PartyClosedException(entryCode.getCode());
+        }
+        if(participantIds.size() < MIN_PARTY_START_MEMBER_SIZE) {
+            throw new NotSatisfyMemberCountException(entryCode.getCode(), participantIds.size());
+        }
+    }
 
     public void quit(final String memberId) {
-        participants.remove(memberId);
+        validateArgumentId(memberId);
+        participantIds.remove(memberId);
         if(memberId.equals(managerId)) {
             status = PartyStatus.CANCELLED;
         }
@@ -48,5 +66,10 @@ public class Party {
 
     public boolean isRecruitClosed() {
         return !status.isWaiting();
+    }
+    private void validateArgumentId(String id) {
+        if(Objects.isNull(id) || id.isBlank()) {
+            throw new IllegalArgumentIdException(id);
+        }
     }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/exception/IllegalArgumentIdException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/exception/IllegalArgumentIdException.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunmatchingservice.domain.party.exception;
+
+import online.partyrun.partyrunmatchingservice.global.exception.BadRequestException;
+
+public class IllegalArgumentIdException extends BadRequestException {
+    public IllegalArgumentIdException(String id) {
+        super(id + " 는 허용되지 않는 값입니다.");
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/exception/NotSatisfyMemberCountException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/exception/NotSatisfyMemberCountException.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunmatchingservice.domain.party.exception;
+
+import online.partyrun.partyrunmatchingservice.global.exception.BadRequestException;
+
+public class NotSatisfyMemberCountException extends BadRequestException {
+    public NotSatisfyMemberCountException(final String code, final int size) {
+        super(code + " 파티가 시작할 수 인원이 부족합니다. 현재 인원 수 :" + size);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/exception/PartyClosedException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/exception/PartyClosedException.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunmatchingservice.domain.party.exception;
+
+import online.partyrun.partyrunmatchingservice.global.exception.BadRequestException;
+
+public class PartyClosedException extends BadRequestException {
+    public PartyClosedException(final String code) {
+        super(code + " 파티는 이미 마감되었습니다.");
+    }
+}

--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/exception/PartyNotFoundException.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/exception/PartyNotFoundException.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunmatchingservice.domain.party.exception;
+
+import online.partyrun.partyrunmatchingservice.global.exception.BadRequestException;
+
+public class PartyNotFoundException extends BadRequestException {
+    public PartyNotFoundException(final String entryCode) {
+        super(entryCode + "에 해당하는 Party를 찾을 수 없습니다.");
+    }
+}

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/party/entity/PartyTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/party/entity/PartyTest.java
@@ -1,10 +1,16 @@
 package online.partyrun.partyrunmatchingservice.domain.party.entity;
 
+import online.partyrun.partyrunmatchingservice.domain.party.exception.IllegalArgumentIdException;
+import online.partyrun.partyrunmatchingservice.domain.party.exception.NotSatisfyMemberCountException;
+import online.partyrun.partyrunmatchingservice.domain.party.exception.PartyClosedException;
 import online.partyrun.partyrunmatchingservice.domain.waiting.root.RunningDistance;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("party에서")
@@ -18,13 +24,15 @@ class PartyTest {
         Party party = new Party(manager, RunningDistance.M1000);
         party.join(member);
 
-        assertThat(party.getParticipants()).contains(member);
+        assertThat(party.getParticipantIds()).contains(member);
     }
 
     @Test
     @DisplayName("시작을 하면 주어진 battle ID로 설정을 하고, COMPLETED로 상태로 변경한다.")
     void start() {
         Party party = new Party(manager, RunningDistance.M1000);
+        party.join(manager);
+        party.join(member);
         String battleId = "battleId";
         party.start(battleId);
 
@@ -52,8 +60,8 @@ class PartyTest {
             party.quit(member);
 
             assertAll(
-                    () -> assertThat(party.getParticipants()).isNotIn(member),
-                    () -> assertThat(party.getParticipants()).contains(manager),
+                    () -> assertThat(party.getParticipantIds()).isNotIn(member),
+                    () -> assertThat(party.getParticipantIds()).contains(manager),
                     () -> assertThat(party.getStatus()).isEqualTo(PartyStatus.WAITING)
             );
         }
@@ -64,10 +72,63 @@ class PartyTest {
             party.quit(manager);
 
             assertAll(
-                    () -> assertThat(party.getParticipants()).isNotIn(manager),
-                    () -> assertThat(party.getParticipants()).contains(member),
+                    () -> assertThat(party.getParticipantIds()).isNotIn(manager),
+                    () -> assertThat(party.getParticipantIds()).contains(member),
                     () -> assertThat(party.getStatus()).isEqualTo(PartyStatus.CANCELLED)
             );
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(ReplaceUnderscores.class)
+    class Argument값이_잘못됐으면 {
+        @ParameterizedTest
+        @NullAndEmptySource
+        @DisplayName("예외를 발생한다")
+        void throwException(String id) {
+            Party party = new Party(manager, RunningDistance.M1000);
+            assertAll(
+                    () -> assertThatThrownBy(() -> party.quit(id)).isInstanceOf(IllegalArgumentIdException.class),
+                    () -> assertThatThrownBy(() -> party.join(id)).isInstanceOf(IllegalArgumentIdException.class),
+                    () -> assertThatThrownBy(() -> party.start(id)).isInstanceOf(IllegalArgumentIdException.class)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(ReplaceUnderscores.class)
+    class Party가_시작할_수_있는_상태가_아닐_때 {
+        final String battleId = "battleId";
+        @Test
+        @DisplayName("party가 이미 completed했을 때 start 시에 예외를 발생한다")
+        void throwExceptionIfPartyComplete() {
+            Party party = new Party(manager, RunningDistance.M1000);
+            party.join(manager);
+            party.join(member);
+            party.start(battleId);
+
+            assertThatThrownBy(() -> party.start(battleId))
+                    .isInstanceOf(PartyClosedException.class);
+        }
+
+        @Test
+        @DisplayName("party가 이미 canceled했을 때 start 시에 예외를 발생한다")
+        void throwExceptionIfPartyCanceled() {
+            Party party = new Party(manager, RunningDistance.M1000);
+            party.join(manager);
+            party.quit(manager);
+            assertThatThrownBy(() -> party.start(battleId))
+                    .isInstanceOf(PartyClosedException.class);
+        }
+
+        @Test
+        @DisplayName("party가 시작할 수 있는 인원에 총족을 못하면 예외를 발생한다")
+        void throwExceptionIfPartyNotSatisfyMemberCount() {
+            Party party = new Party(manager, RunningDistance.M1000);
+            party.join(manager);
+
+            assertThatThrownBy(() -> party.start(battleId))
+                    .isInstanceOf(NotSatisfyMemberCountException.class);
         }
     }
 }


### PR DESCRIPTION
## 변경 사항
1. 클라이언트 측과의 협의 하에 기존 participants를 ParticipantIds로 이름을 변경했습니다.
2. ParticipantIds Collection을 List에서 Set으로 변경했습니다. 중복을 허용하지 않고, 순서 보장이 필요 없기에 자료구조를 변경했습니다.

3. Party에 대한 Arguments 검증 및 State 검증 로직을 추가하였습니다.
3-1. 전반적인 Arguments에서 String 값이 null 혹은 Blank일 때 검증
3-2. 파티가 이미 모집이 완료됐거나, 캔슬됐을 때 시작 불가
3-3. 파티가 인원수가 충족하지 않으면 시작 불가

4. PartyService에서 사용자가 요청한 Party를 탐색하지 못했을 때의 예외 처리를 추가하였습니다.