### PR TITLE
refactor : timeout을 핸들러 별로 별도 설정이 가능하게 변경

### DIFF
--- a/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/service/PartySinkHandler.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/domain/party/service/PartySinkHandler.java
@@ -4,6 +4,14 @@ import online.partyrun.partyrunmatchingservice.domain.party.dto.PartyEvent;
 import online.partyrun.partyrunmatchingservice.global.sse.SinkHandlerTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+
 @Component
 public class PartySinkHandler extends SinkHandlerTemplate<String, PartyEvent> {
+    private static final int PARTY_TIME_OUT_MINUTES = 10;
+
+    @Override
+    protected Duration timeout() {
+        return Duration.ofMinutes(PARTY_TIME_OUT_MINUTES);
+    }
 }

--- a/src/main/java/online/partyrun/partyrunmatchingservice/global/sse/SinkHandlerTemplate.java
+++ b/src/main/java/online/partyrun/partyrunmatchingservice/global/sse/SinkHandlerTemplate.java
@@ -72,7 +72,7 @@ public abstract class SinkHandlerTemplate<K, V> {
         return sinks.containsKey(key);
     }
 
-    private Duration timeout() {
+    protected Duration timeout() {
         return Duration.ofMinutes(DEFAULT_MINUTE);
     }
 

--- a/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/domain/matching/service/MatchingServiceTest.java
@@ -144,8 +144,6 @@ class MatchingServiceTest {
 
         @BeforeEach
         void setup() {
-            matchingRepository.deleteAll().block();
-            sseHandler.shutdown();
             matching = matchingService.create(members, distance).block();
             matchingService.setMemberStatus(Mono.just(현준), 수락).block();
             matchingService.setMemberStatus(Mono.just(성우), 수락).block();


### PR DESCRIPTION
## 변경 사항

기존 SinkHandlerTemplate를 하위 클래스가 Override 하여 timeout 시간을 커스텀하도록 변경하였습니다.

클라이언트 측 협의에 따라 party connction에 대한 timeout은 10분으로 재설정하였습니다. 
