### PR TITLE
feat : embedded redis를 testcontainer로 대체

### DIFF
--- a/.github/workflows/build-docker-image-dev.yml
+++ b/.github/workflows/build-docker-image-dev.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - name: Setup Testcontainers Cloud Client
+        uses: atomicjar/testcontainers-cloud-setup-action@v1
+        with:
+          token: ${{ secrets.TC_CLOUD_TOKEN }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2.1.0

--- a/.github/workflows/build-docker-image-prd.yml
+++ b/.github/workflows/build-docker-image-prd.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - name: Setup Testcontainers Cloud Client
+        uses: atomicjar/testcontainers-cloud-setup-action@v1
+        with:
+          token: ${{ secrets.TC_CLOUD_TOKEN }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2.1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ jobs:
         with:
           java-version: "17"
           distribution: "temurin"
+      - name: Setup Testcontainers Cloud Client
+        uses: atomicjar/testcontainers-cloud-setup-action@v1
+        with:
+          token: ${{ secrets.TC_CLOUD_TOKEN }}
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
       - name: Build with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,8 @@ dependencies {
     //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter:1.19.0'
 
     //rest docs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
@@ -80,9 +82,6 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
-    testImplementation('it.ozimov:embedded-redis:0.7.3') {
-        exclude group: 'org.slf4j', module: 'slf4j-simple'
-    }
 
     // mongodb
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'

--- a/src/test/java/online/partyrun/partyrunmatchingservice/config/redis/RedisTestConfig.java
+++ b/src/test/java/online/partyrun/partyrunmatchingservice/config/redis/RedisTestConfig.java
@@ -1,13 +1,29 @@
 package online.partyrun.partyrunmatchingservice.config.redis;
 
+import jakarta.annotation.PreDestroy;
 import org.springframework.boot.test.context.TestConfiguration;
-import redis.embedded.RedisServer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration
 public class RedisTestConfig {
 
-    private static RedisServer redisServer = new RedisServer(6379);
+    private static final int REDIS_PORT = 6379;
+
+    @Container
+    private static GenericContainer<?> REDIS = new GenericContainer<>(DockerImageName.parse("redis:7.0.8-alpine"))
+            .withExposedPorts(REDIS_PORT);
+
     static {
-        redisServer.start();
+        REDIS.start();
+        System.setProperty("spring.data.redis.host", REDIS.getHost());
+        System.setProperty("spring.data.redis.port", String.valueOf(REDIS.getMappedPort(REDIS_PORT)));
+    }
+
+    @PreDestroy
+    void preDestroy() {
+        REDIS.stop();
     }
 }
+


### PR DESCRIPTION
## 변경 사항

mac os 14 sonoma로 업데이트 이후, embedded redis가 호환이 안되는 문제가 발생하였습니다.
따라서, embedded redis를 제거한 후 test-container 사용하는 방안으로 변경하였습니다.

## 테스트 방식
